### PR TITLE
miner/worker: skip the uncle and resubmit logic in Consortium

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -456,6 +456,10 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			commit(false, commitInterruptNewHead)
 
 		case <-timer.C:
+			if w.chainConfig.Consortium != nil {
+				continue
+			}
+
 			// If mining is running resubmit a new work cycle periodically to pull in
 			// higher priced transactions. Disable this overhead for pending blocks.
 			if w.isRunning() && (w.chainConfig.Clique == nil || w.chainConfig.Clique.Period > 0) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -525,6 +525,10 @@ func (w *worker) mainLoop() {
 			w.commitNewWork(req.interrupt, req.noempty, req.timestamp)
 
 		case ev := <-w.chainSideCh:
+			// Don't handle uncle logic in Consortium
+			if w.chainConfig.Consortium != nil {
+				continue
+			}
 			// Short circuit for duplicate side blocks
 			if _, exist := w.localUncles[ev.Block.Hash()]; exist {
 				continue


### PR DESCRIPTION
- miner/worker: skip the uncle logic in Consortium
In Consortium consensus engine, we don't handle uncle blocks. Furthermore, the
uncle logic in worker may block the main creating block logic. So this commit
skips the uncle logic when Consortium consensus engine is used.

- miner/worker: skip resubmit logic in Consortium
Currently, after 3 seconds, worker tries to create another block, optimistically
thinks that it can get more transactions and earns more fee as a result.
However, this causes overhead to the main block creating flow, so skip this
logic in Consortium.