### PR TITLE
internal/ethapi: eth_call block parameter is optional (#28165)

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -435,7 +435,7 @@ func (c *ContractIntegrator) contractCall(
 			Gas:  &gas,
 			To:   &to,
 			Data: &msgData,
-		}, blockNrOrHash, nil, nil)
+		}, &blockNrOrHash, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -635,7 +635,7 @@ func (b *ConsortiumBackend) CallContract(ctx context.Context, call ethereum.Call
 		Gas:  &gas,
 		To:   call.To,
 		Data: &data,
-	}, block, nil, nil)
+	}, &block, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1149,8 +1149,12 @@ func (e *revertError) ErrorData() interface{} {
 //
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
-func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
-	result, err := DoCall(ctx, s.b, args, blockNrOrHash, overrides, blockOverrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
+func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
+	if blockNrOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		blockNrOrHash = &latest
+	}
+	result, err := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, blockOverrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -922,7 +922,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 	for i, tc := range testSuite {
-		result, err := api.Call(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, &tc.overrides, &tc.blockOverrides)
+		result, err := api.Call(context.Background(), tc.call, &rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, &tc.overrides, &tc.blockOverrides)
 		if tc.expectErr != nil {
 			if err == nil {
 				t.Errorf("test %d: want error %v, have nothing", i, tc.expectErr)


### PR DESCRIPTION
commit https://github.com/ethereum/go-ethereum/commit/adb9b319c9c61f092755000bf0fc4b3349f5cbbc.

Make the block parameter in eth_call is optional following the specification. The default value when block parameter is not provided is "latest".