### PR TITLE
eth: disable transaction broadcast based on originated peer

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -154,6 +154,7 @@ var (
 		utils.NodeKeyHexFlag,
 		utils.DNSDiscoveryFlag,
 		utils.TrustedNodesOnlyFlag,
+		utils.DisableTxBroadcastFromFlag,
 		utils.MainnetFlag,
 		utils.DeveloperFlag,
 		utils.DeveloperPeriodFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -73,6 +73,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
@@ -883,6 +884,11 @@ var (
 	TrustedNodesOnlyFlag = &cli.BoolFlag{
 		Name:     "trusted-node-only",
 		Usage:    "Only accept p2p connection from a trusted node",
+		Category: flags.NetworkingCategory,
+	}
+	DisableTxBroadcastFromFlag = &cli.StringFlag{
+		Name:     "disable-tx-broadcast.from",
+		Usage:    "Comma separated v4 node ids from which transactions are not broadcasted",
 		Category: flags.NetworkingCategory,
 	}
 
@@ -2127,6 +2133,26 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	log.Info("Initializing the KZG library", "backend", ctx.String(CryptoKZGFlag.Name))
 	if err := kzg4844.UseCKZG(ctx.String(CryptoKZGFlag.Name) == "ckzg"); err != nil {
 		Fatalf("Failed to set KZG library implementation to %s: %v", ctx.String(CryptoKZGFlag.Name), err)
+	}
+	if ctx.IsSet(DisableTxBroadcastFromFlag.Name) {
+		scheme := enode.V4ID{}
+		nodeIds := SplitAndTrim(ctx.String(DisableTxBroadcastFromFlag.Name))
+		peerIds := make([]string, 0, len(nodeIds))
+		for _, nodeId := range nodeIds {
+			pubkey, err := enode.ParsePubkey(nodeId)
+			if err != nil {
+				log.Error("Failed to parse node id", "id", nodeId, "err", err)
+				peerIds = []string{}
+				break
+			}
+
+			var record enr.Record
+			record.Set((*enode.Secp256k1)(pubkey))
+			enodeId := (enode.ID)(scheme.NodeAddr(&record))
+			peerIds = append(peerIds, enodeId.String())
+		}
+
+		cfg.DisableTxBroadcastFrom = peerIds
 	}
 }
 

--- a/core/txpool/blobpool/blobpool_test.go
+++ b/core/txpool/blobpool/blobpool_test.go
@@ -240,9 +240,9 @@ func verifyPoolInternals(t *testing.T, pool *BlobPool) {
 			seen[tx.hash] = struct{}{}
 		}
 	}
-	for hash, id := range pool.lookup.txIndex {
+	for hash, meta := range pool.lookup.txIndex {
 		if _, ok := seen[hash]; !ok {
-			t.Errorf("tx lookup entry missing from transaction index: hash #%x, id %d", hash, id)
+			t.Errorf("tx lookup entry missing from transaction index: hash #%x, id %d", hash, meta.id)
 		}
 		delete(seen, hash)
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1054,18 +1054,19 @@ func (pool *LegacyPool) Get(hash common.Hash) *types.Transaction {
 	return pool.all.Get(hash)
 }
 
-// GetRLP returns a RLP-encoded transaction if it is contained in the pool.
-func (pool *LegacyPool) GetRLP(hash common.Hash) []byte {
+// GetRLP returns a RLP-encoded transaction and broadcast status if it is contained
+// in the pool.
+func (pool *LegacyPool) GetRLP(hash common.Hash) ([]byte, bool) {
 	tx := pool.all.Get(hash)
 	if tx == nil {
-		return nil
+		return nil, false
 	}
 	encoded, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		log.Error("Failed to encoded transaction in legacy pool", "hash", hash, "err", err)
-		return nil
+		return nil, false
 	}
-	return encoded
+	return encoded, !tx.IsNoBroadcast()
 }
 
 // GetBlobs is not supported by the legacy transaction pool, it is just here to

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -129,8 +129,9 @@ type SubPool interface {
 	// Get returns a transaction if it is contained in the pool, or nil otherwise.
 	Get(hash common.Hash) *types.Transaction
 
-	// GetRLP returns a RLP-encoded transaction if it is contained in the pool.
-	GetRLP(hash common.Hash) []byte
+	// GetRLP returns a RLP-encoded transaction, broadcast status if it is contained
+	// in the pool.
+	GetRLP(hash common.Hash) ([]byte, bool)
 
 	// GetBlobs returns a number of blobs are proofs for the given versioned hashes.
 	// This is a utility method for the engine API, enabling consensus clients to

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -290,15 +290,16 @@ func (p *TxPool) Get(hash common.Hash) *types.Transaction {
 	return nil
 }
 
-// GetRLP returns a RLP-encoded transaction if it is contained in the pool.
-func (p *TxPool) GetRLP(hash common.Hash) []byte {
+// GetRLP returns a RLP-encoded transaction and broadcast status if it is
+// contained in the pool.
+func (p *TxPool) GetRLP(hash common.Hash) ([]byte, bool) {
 	for _, subpool := range p.subpools {
-		encoded := subpool.GetRLP(hash)
+		encoded, canBroadcast := subpool.GetRLP(hash)
 		if len(encoded) != 0 {
-			return encoded
+			return encoded, canBroadcast
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // GetBlobs returns a number of blobs are proofs for the given versioned hashes.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -60,6 +60,8 @@ type Transaction struct {
 	size  atomic.Value
 	from  atomic.Value
 	payer atomic.Value
+
+	noBroadcast bool
 }
 
 // NewTx creates a new transaction.
@@ -530,6 +532,14 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	cpy := tx.inner.copy()
 	cpy.setSignatureValues(signer.ChainID(), v, r, s)
 	return &Transaction{inner: cpy, time: tx.time}, nil
+}
+
+func (tx *Transaction) IsNoBroadcast() bool {
+	return tx.noBroadcast
+}
+
+func (tx *Transaction) SetNoBroadcast() {
+	tx.noBroadcast = true
 }
 
 // Transactions implements DerivableList for transactions.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -249,17 +249,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		checkpoint = params.TrustedCheckpoints[genesisHash]
 	}
 	if eth.handler, err = newHandler(&handlerConfig{
-		NodeID:               eth.p2pServer.Self().ID(),
-		Database:             chainDb,
-		Chain:                eth.blockchain,
-		TxPool:               eth.txPool,
-		Network:              config.NetworkId,
-		Sync:                 config.SyncMode,
-		BloomCache:           uint64(cacheLimit),
-		EventMux:             eth.eventMux,
-		Checkpoint:           checkpoint,
-		Whitelist:            config.Whitelist,
-		DisableRoninProtocol: config.DisableRoninProtocol,
+		NodeID:                 eth.p2pServer.Self().ID(),
+		Database:               chainDb,
+		Chain:                  eth.blockchain,
+		TxPool:                 eth.txPool,
+		Network:                config.NetworkId,
+		Sync:                   config.SyncMode,
+		BloomCache:             uint64(cacheLimit),
+		EventMux:               eth.eventMux,
+		Checkpoint:             checkpoint,
+		Whitelist:              config.Whitelist,
+		DisableRoninProtocol:   config.DisableRoninProtocol,
+		DisableTxBroadcastFrom: config.DisableTxBroadcastFrom,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -237,6 +237,9 @@ type Config struct {
 
 	// Send additional chain event
 	EnableAdditionalChainEvent bool
+
+	// Don't broadcast transactions that are originated from these peer ids
+	DisableTxBroadcastFrom []string
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -75,9 +75,9 @@ type txPool interface {
 	// tx hash.
 	Get(hash common.Hash) *types.Transaction
 
-	// GetRLP retrieves the RLP-encoded transaction from local txpool
-	// with given tx hash.
-	GetRLP(hash common.Hash) []byte
+	// GetRLP retrieves the RLP-encoded transaction and broadcast status
+	// from local txpool with given tx hash.
+	GetRLP(hash common.Hash) ([]byte, bool)
 
 	// Add should add the given transactions to the pool.
 	Add(txs []*types.Transaction, local bool, sync bool) []error
@@ -94,18 +94,19 @@ type txPool interface {
 // handlerConfig is the collection of initialization parameters to create a full
 // node network handler.
 type handlerConfig struct {
-	NodeID               enode.ID                  // P2P node ID used for tx propagation topology
-	Database             ethdb.Database            // Database for direct sync insertions
-	Chain                *core.BlockChain          // Blockchain to serve data from
-	TxPool               txPool                    // Transaction pool to propagate from
-	Network              uint64                    // Network identifier to adfvertise
-	Sync                 downloader.SyncMode       // Whether to fast or full sync
-	BloomCache           uint64                    // Megabytes to alloc for fast sync bloom
-	EventMux             *event.TypeMux            // Legacy event mux, deprecate for `feed`
-	Checkpoint           *params.TrustedCheckpoint // Hard coded checkpoint for sync challenges
-	Whitelist            map[uint64]common.Hash    // Hard coded whitelist for sync challenged
-	DisableRoninProtocol bool                      // Ronin protocol is enabled
-	VotePool             *vote.VotePool            // Vote pool when fast finality is enabled
+	NodeID                 enode.ID                  // P2P node ID used for tx propagation topology
+	Database               ethdb.Database            // Database for direct sync insertions
+	Chain                  *core.BlockChain          // Blockchain to serve data from
+	TxPool                 txPool                    // Transaction pool to propagate from
+	Network                uint64                    // Network identifier to adfvertise
+	Sync                   downloader.SyncMode       // Whether to fast or full sync
+	BloomCache             uint64                    // Megabytes to alloc for fast sync bloom
+	EventMux               *event.TypeMux            // Legacy event mux, deprecate for `feed`
+	Checkpoint             *params.TrustedCheckpoint // Hard coded checkpoint for sync challenges
+	Whitelist              map[uint64]common.Hash    // Hard coded whitelist for sync challenged
+	DisableRoninProtocol   bool                      // Ronin protocol is enabled
+	VotePool               *vote.VotePool            // Vote pool when fast finality is enabled
+	DisableTxBroadcastFrom []string
 }
 
 type handler struct {
@@ -151,6 +152,8 @@ type handler struct {
 	votePool             *vote.VotePool
 	voteCh               chan core.NewVoteEvent
 	voteSub              event.Subscription
+
+	disableTxBroadcastFrom map[string]struct{}
 }
 
 // newHandler returns a handler for all Ethereum chain management protocol.
@@ -160,20 +163,24 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		config.EventMux = new(event.TypeMux) // Nicety initialization for tests
 	}
 	h := &handler{
-		nodeID:               config.NodeID,
-		networkID:            config.Network,
-		forkFilter:           forkid.NewFilter(config.Chain),
-		eventMux:             config.EventMux,
-		database:             config.Database,
-		txpool:               config.TxPool,
-		chain:                config.Chain,
-		peers:                newPeerSet(),
-		whitelist:            config.Whitelist,
-		quitSync:             make(chan struct{}),
-		handlerDoneCh:        make(chan struct{}),
-		handlerStartCh:       make(chan struct{}),
-		disableRoninProtocol: config.DisableRoninProtocol,
-		votePool:             config.VotePool,
+		nodeID:                 config.NodeID,
+		networkID:              config.Network,
+		forkFilter:             forkid.NewFilter(config.Chain),
+		eventMux:               config.EventMux,
+		database:               config.Database,
+		txpool:                 config.TxPool,
+		chain:                  config.Chain,
+		peers:                  newPeerSet(),
+		whitelist:              config.Whitelist,
+		quitSync:               make(chan struct{}),
+		handlerDoneCh:          make(chan struct{}),
+		handlerStartCh:         make(chan struct{}),
+		disableRoninProtocol:   config.DisableRoninProtocol,
+		votePool:               config.VotePool,
+		disableTxBroadcastFrom: make(map[string]struct{}),
+	}
+	for _, peerId := range config.DisableTxBroadcastFrom {
+		h.disableTxBroadcastFrom[peerId] = struct{}{}
 	}
 	if config.Sync == downloader.FullSync {
 		// The database seems empty as the current block is the genesis. Yet the fast
@@ -613,6 +620,11 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 		hash   = make([]byte, 32)
 	)
 	for _, tx := range txs {
+		if tx.IsNoBroadcast() {
+			log.Debug("Transaction is not allowed to be broadcasted", "hash", tx.Hash())
+			continue
+		}
+
 		var maybeDirect bool
 		switch {
 		case tx.Type() == types.BlobTxType:

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -85,18 +85,18 @@ func (p *testTxPool) Get(hash common.Hash) *types.Transaction {
 	return p.pool[hash]
 }
 
-// Get retrieves the transaction from local txpool with given
-// tx hash.
-func (p *testTxPool) GetRLP(hash common.Hash) []byte {
+// Get retrieves the transaction and broadcast status from
+// local txpool with given tx hash.
+func (p *testTxPool) GetRLP(hash common.Hash) ([]byte, bool) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	tx := p.pool[hash]
 	if tx != nil {
 		blob, _ := rlp.EncodeToBytes(tx)
-		return blob
+		return blob, !tx.IsNoBroadcast()
 	}
-	return nil
+	return nil, false
 }
 
 // AddRemotes appends a batch of transactions to the pool, and notifies any

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -105,9 +105,9 @@ type TxPool interface {
 	// Get retrieves the transaction from the local txpool with the given hash.
 	Get(hash common.Hash) *types.Transaction
 
-	// GetRLP retrieves the RLP-encoded transaction from the local txpool with
-	// the given hash.
-	GetRLP(hash common.Hash) []byte
+	// GetRLP retrieves the RLP-encoded transaction and broadcast status from the
+	// local txpool with the given hash.
+	GetRLP(hash common.Hash) ([]byte, bool)
 }
 
 // MakeProtocols constructs the P2P protocol definitions for `eth`.

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -459,8 +459,8 @@ func answerGetPooledTransactions(backend Backend, query GetPooledTransactionsPac
 			break
 		}
 		// Retrieve the requested transaction, skipping if unknown to us
-		encoded := backend.TxPool().GetRLP(hash)
-		if len(encoded) == 0 {
+		encoded, canBroadcast := backend.TxPool().GetRLP(hash)
+		if len(encoded) == 0 || !canBroadcast {
 			continue
 		}
 		hashes = append(hashes, hash)

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -71,7 +71,7 @@ func MustParseV4(rawurl string) *Node {
 //    enode://<hex node id>@10.3.58.6:30303?discport=30301
 func ParseV4(rawurl string) (*Node, error) {
 	if m := incompleteNodeURL.FindStringSubmatch(rawurl); m != nil {
-		id, err := parsePubkey(m[1])
+		id, err := ParsePubkey(m[1])
 		if err != nil {
 			return nil, fmt.Errorf("invalid public key (%v)", err)
 		}
@@ -123,7 +123,7 @@ func parseComplete(rawurl string) (*Node, error) {
 	if u.User == nil {
 		return nil, errors.New("does not contain node ID")
 	}
-	if id, err = parsePubkey(u.User.String()); err != nil {
+	if id, err = ParsePubkey(u.User.String()); err != nil {
 		return nil, fmt.Errorf("invalid public key (%v)", err)
 	}
 	// Parse the IP address.
@@ -154,8 +154,8 @@ func parseComplete(rawurl string) (*Node, error) {
 	return NewV4(id, ip, int(tcpPort), int(udpPort)), nil
 }
 
-// parsePubkey parses a hex-encoded secp256k1 public key.
-func parsePubkey(in string) (*ecdsa.PublicKey, error) {
+// ParsePubkey parses a hex-encoded secp256k1 public key.
+func ParsePubkey(in string) (*ecdsa.PublicKey, error) {
 	b, err := hex.DecodeString(in)
 	if err != nil {
 		return nil, err

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -158,7 +158,7 @@ var parseNodeTests = []struct {
 }
 
 func hexPubkey(h string) *ecdsa.PublicKey {
-	k, err := parsePubkey(h)
+	k, err := ParsePubkey(h)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This commit adds a flag --disable-tx-broadcast.from so that node operator can provide enode ids (e.g. --disable-tx-broadcast.from cfa5f00c55eba79f359c9d95f5c0b2bb8e173867ffbb6e212c6799a52918502519e56650970e34caf1cd17418d4da46c3243588578886c3b4f8c42d1934bf108). Transaction originated from the peer has those enode ids will not be broadcasted to any other peers.