### PR TITLE
go.mod: bump blst to version 0.3.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/holiman/billy v0.0.0-20240322075458-72a4e81ec6da
 	github.com/klauspost/compress v1.17.8
 	github.com/pkg/errors v0.9.1
-	github.com/supranational/blst v0.3.11
+	github.com/supranational/blst v0.3.14
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.3.1
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d

--- a/go.sum
+++ b/go.sum
@@ -767,8 +767,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
-github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
+github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=


### PR DESCRIPTION
The new blst version fixes this build issue with go1.24.
```
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:207:11: cannot define new methods on non-local type SecretKey
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:310:15: cannot define new methods on non-local type SecretKey
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:430:11: cannot define new methods on non-local type Fp12
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:434:11: cannot define new methods on non-local type Fp12
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:438:11: cannot define new methods on non-local type Fp12
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:442:11: cannot define new methods on non-local type Fp12
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:448:12: cannot define new methods on non-local type Fp12
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:460:11: cannot define new methods on non-local type P1Affine
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:465:11: cannot define new methods on non-local type P1Affine
../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:474:12: cannot define new methods on non-local type P2Affine
```
Reference:
- blst commit: https://github.com/supranational/blst/commit/df47c4cbbc3f7284507b141c2fc3175874024768
- go-ethereum commit: https://github.com/ethereum/go-ethereum/commit/24ed0b506602cf18e92c2ec5b75173a68178748b