### PR TITLE
core/state_transition: Avoid out of gas when tracing system txs

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -334,7 +334,7 @@ func (st *StateTransition) preCheck() error {
 			}
 			// This will panic if baseFee is nil, but basefee presence is verified
 			// as part of header validation.
-			if st.gasFeeCap.Cmp(st.evm.Context.BaseFee) < 0 {
+			if !st.evm.Config.IsSystemTransaction && st.gasFeeCap.Cmp(st.evm.Context.BaseFee) < 0 {
 				return fmt.Errorf("%w: address %v, maxFeePerGas: %s baseFee: %s", ErrFeeCapTooLow,
 					msg.From().Hex(), st.gasFeeCap, st.evm.Context.BaseFee)
 			}
@@ -420,10 +420,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
 	// Check clauses 1-3, buy gas if everything is correct
-	if !st.evm.Config.IsSystemTransaction {
-		if err := st.preCheck(); err != nil {
-			return nil, err
-		}
+	if err := st.preCheck(); err != nil {
+		return nil, err
 	}
 
 	if tracer := st.evm.Config.Tracer; tracer != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -317,7 +317,7 @@ func (st *StateTransition) preCheck() error {
 		}
 	}
 	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
-	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
+	if !st.evm.Config.IsSystemTransaction && st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
 		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
 			if l := st.gasFeeCap.BitLen(); l > 256 {
@@ -334,7 +334,7 @@ func (st *StateTransition) preCheck() error {
 			}
 			// This will panic if baseFee is nil, but basefee presence is verified
 			// as part of header validation.
-			if !st.evm.Config.IsSystemTransaction && st.gasFeeCap.Cmp(st.evm.Context.BaseFee) < 0 {
+			if st.gasFeeCap.Cmp(st.evm.Context.BaseFee) < 0 {
 				return fmt.Errorf("%w: address %v, maxFeePerGas: %s baseFee: %s", ErrFeeCapTooLow,
 					msg.From().Hex(), st.gasFeeCap, st.evm.Context.BaseFee)
 			}

--- a/eth/tracers/internal/tracetest/calltrace2_test.go
+++ b/eth/tracers/internal/tracetest/calltrace2_test.go
@@ -116,10 +116,11 @@ type callTracer2Test struct {
 }
 
 func TestCallTracer2Native(t *testing.T) {
-	testCallTracer2("callTracer2", "call_tracer2", t)
+	testCallTracer2("callTracer2", "call_tracer2", rawdb.HashScheme, t)
+	testCallTracer2("callTracer2", "call_tracer2", rawdb.PathScheme, t)
 }
 
-func testCallTracer2(tracerName string, dirPath string, t *testing.T) {
+func testCallTracer2(tracerName string, dirPath string, scheme string, t *testing.T) {
 	files, err := ioutil.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
@@ -162,7 +163,7 @@ func testCallTracer2(tracerName string, dirPath string, t *testing.T) {
 					Difficulty:  (*big.Int)(test.Context.Difficulty),
 					GasLimit:    uint64(test.Context.GasLimit),
 				}
-				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			defer triedb.Close()
 			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -81,18 +81,21 @@ type callTracerTest struct {
 // Iterates over all the input-output datasets in the tracer test harness and
 // runs the JavaScript tracers against them.
 func TestCallTracerLegacy(t *testing.T) {
-	testCallTracer("callTracerLegacy", "call_tracer_legacy", t)
+	testCallTracer("callTracerLegacy", "call_tracer_legacy", rawdb.HashScheme, t)
+	testCallTracer("callTracerLegacy", "call_tracer_legacy", rawdb.PathScheme, t)
 }
 
 func TestCallTracerNative(t *testing.T) {
-	testCallTracer("callTracer", "call_tracer", t)
+	testCallTracer("callTracer", "call_tracer", rawdb.HashScheme, t)
+	testCallTracer("callTracer", "call_tracer", rawdb.PathScheme, t)
 }
 
 func TestCallTracerNativeWithLog(t *testing.T) {
-	testCallTracer("callTracer", "call_tracer_withLog", t)
+	testCallTracer("callTracer", "call_tracer_withLog", rawdb.HashScheme, t)
+	testCallTracer("callTracer", "call_tracer_withLog", rawdb.PathScheme, t)
 }
 
-func testCallTracer(tracerName string, dirPath string, t *testing.T) {
+func testCallTracer(tracerName string, dirPath string, scheme string, t *testing.T) {
 	isLegacy := strings.HasSuffix(dirPath, "_legacy")
 	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
@@ -137,7 +140,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 					GasLimit:    uint64(test.Context.GasLimit),
 					BaseFee:     test.Genesis.BaseFee,
 				}
-				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			triedb.Close()
 			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -53,18 +53,21 @@ type testcase struct {
 }
 
 func TestPrestateTracerLegacy(t *testing.T) {
-	testPrestateDiffTracer("prestateTracerLegacy", "prestate_tracer_legacy", t)
+	testPrestateDiffTracer("prestateTracerLegacy", "prestate_tracer_legacy", rawdb.HashScheme, t)
+	testPrestateDiffTracer("prestateTracerLegacy", "prestate_tracer_legacy", rawdb.PathScheme, t)
 }
 
 func TestPrestateTracer(t *testing.T) {
-	testPrestateDiffTracer("prestateTracer", "prestate_tracer", t)
+	testPrestateDiffTracer("prestateTracer", "prestate_tracer", rawdb.HashScheme, t)
+	testPrestateDiffTracer("prestateTracer", "prestate_tracer", rawdb.PathScheme, t)
 }
 
 func TestPrestateWithDiffModeTracer(t *testing.T) {
-	testPrestateDiffTracer("prestateTracer", "prestate_tracer_with_diff_mode", t)
+	testPrestateDiffTracer("prestateTracer", "prestate_tracer_with_diff_mode", rawdb.HashScheme, t)
+	testPrestateDiffTracer("prestateTracer", "prestate_tracer_with_diff_mode", rawdb.PathScheme, t)
 }
 
-func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
+func testPrestateDiffTracer(tracerName string, dirPath string, scheme string, t *testing.T) {
 	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
@@ -108,7 +111,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 					GasLimit:    uint64(test.Context.GasLimit),
 					BaseFee:     test.Genesis.BaseFee,
 				}
-				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			defer triedb.Close()
 			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)


### PR DESCRIPTION
fix for changes related to https://github.com/axieinfinity/ronin/pull/565.It will be failed when try to apply txs for tracing system transtions with error "out of gas" because the ts.gas return 0 when bypassing Precheck logic in first step.