### PR TITLE
eth/feehistory: set reward of system transaction to 0

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -132,6 +132,11 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	sorter := make(sortGasAndReward, len(bf.block.Transactions()))
 	for i, tx := range bf.block.Transactions() {
 		reward, _ := tx.EffectiveGasTip(bf.block.BaseFee())
+		// Only system transaction may result in negative reward.
+		// Fix it up by setting the reward to 0.
+		if reward.Sign() == -1 {
+			reward = common.Big0
+		}
 		sorter[i] = txGasAndReward{gasUsed: bf.receipts[i].GasUsed, reward: reward}
 	}
 	sort.Sort(sorter)


### PR DESCRIPTION
The returned reward of system transaction is negative. This is because system transaction does not follow basefee rule. This commit fixes the issue by setting the returned reward of system transaction to 0.