### PR TITLE
p2p/discover: improved node revalidation

### DIFF
--- a/common/mclock/alarm.go
+++ b/common/mclock/alarm.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package mclock
+
+import (
+	"time"
+)
+
+// Alarm sends timed notifications on a channel. This is very similar to a regular timer,
+// but is easier to use in code that needs to re-schedule the same timer over and over.
+//
+// When scheduling an Alarm, the channel returned by C() will receive a value no later
+// than the scheduled time. An Alarm can be reused after it has fired and can also be
+// canceled by calling Stop.
+type Alarm struct {
+	ch       chan struct{}
+	clock    Clock
+	timer    Timer
+	deadline AbsTime
+}
+
+// NewAlarm creates an Alarm.
+func NewAlarm(clock Clock) *Alarm {
+	if clock == nil {
+		panic("nil clock")
+	}
+	return &Alarm{
+		ch:    make(chan struct{}, 1),
+		clock: clock,
+	}
+}
+
+// C returns the alarm notification channel. This channel remains identical for
+// the entire lifetime of the alarm, and is never closed.
+func (e *Alarm) C() <-chan struct{} {
+	return e.ch
+}
+
+// Stop cancels the alarm and drains the channel.
+// This method is not safe for concurrent use.
+func (e *Alarm) Stop() {
+	// Clear timer.
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+	e.deadline = 0
+
+	// Drain the channel.
+	select {
+	case <-e.ch:
+	default:
+	}
+}
+
+// Schedule sets the alarm to fire no later than the given time. If the alarm was already
+// scheduled but has not fired yet, it may fire earlier than the newly-scheduled time.
+func (e *Alarm) Schedule(time AbsTime) {
+	now := e.clock.Now()
+	e.schedule(now, time)
+}
+
+func (e *Alarm) schedule(now, newDeadline AbsTime) {
+	if e.timer != nil {
+		if e.deadline > now && e.deadline <= newDeadline {
+			// Here, the current timer can be reused because it is already scheduled to
+			// occur earlier than the new deadline.
+			//
+			// The e.deadline > now part of the condition is important. If the old
+			// deadline lies in the past, we assume the timer has already fired and needs
+			// to be rescheduled.
+			return
+		}
+		e.timer.Stop()
+	}
+
+	// Set the timer.
+	d := time.Duration(0)
+	if newDeadline < now {
+		newDeadline = now
+	} else {
+		d = newDeadline.Sub(now)
+	}
+	e.timer = e.clock.AfterFunc(d, e.send)
+	e.deadline = newDeadline
+}
+
+func (e *Alarm) send() {
+	select {
+	case e.ch <- struct{}{}:
+	default:
+	}
+}

--- a/common/mclock/alarm_test.go
+++ b/common/mclock/alarm_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package mclock
+
+import "testing"
+
+// This test checks basic functionality of Alarm.
+func TestAlarm(t *testing.T) {
+	clk := new(Simulated)
+	clk.Run(20)
+	a := NewAlarm(clk)
+
+	a.Schedule(clk.Now() + 10)
+	if recv(a.C()) {
+		t.Fatal("Alarm fired before scheduled deadline")
+	}
+	if ntimers := clk.ActiveTimers(); ntimers != 1 {
+		t.Fatal("clock has", ntimers, "active timers, want", 1)
+	}
+	clk.Run(5)
+	if recv(a.C()) {
+		t.Fatal("Alarm fired too early")
+	}
+
+	clk.Run(5)
+	if !recv(a.C()) {
+		t.Fatal("Alarm did not fire")
+	}
+	if recv(a.C()) {
+		t.Fatal("Alarm fired twice")
+	}
+	if ntimers := clk.ActiveTimers(); ntimers != 0 {
+		t.Fatal("clock has", ntimers, "active timers, want", 0)
+	}
+
+	a.Schedule(clk.Now() + 5)
+	if recv(a.C()) {
+		t.Fatal("Alarm fired before scheduled deadline when scheduling the second event")
+	}
+
+	clk.Run(5)
+	if !recv(a.C()) {
+		t.Fatal("Alarm did not fire when scheduling the second event")
+	}
+	if recv(a.C()) {
+		t.Fatal("Alarm fired twice when scheduling the second event")
+	}
+}
+
+// This test checks that scheduling an Alarm to an earlier time than the
+// one already scheduled works properly.
+func TestAlarmScheduleEarlier(t *testing.T) {
+	clk := new(Simulated)
+	clk.Run(20)
+	a := NewAlarm(clk)
+
+	a.Schedule(clk.Now() + 50)
+	clk.Run(5)
+	a.Schedule(clk.Now() + 1)
+	clk.Run(3)
+	if !recv(a.C()) {
+		t.Fatal("Alarm did not fire")
+	}
+}
+
+// This test checks that scheduling an Alarm to a later time than the
+// one already scheduled works properly.
+func TestAlarmScheduleLater(t *testing.T) {
+	clk := new(Simulated)
+	clk.Run(20)
+	a := NewAlarm(clk)
+
+	a.Schedule(clk.Now() + 50)
+	clk.Run(5)
+	a.Schedule(clk.Now() + 100)
+	clk.Run(50)
+	if !recv(a.C()) {
+		t.Fatal("Alarm did not fire")
+	}
+}
+
+// This test checks that scheduling an Alarm in the past makes it fire immediately.
+func TestAlarmNegative(t *testing.T) {
+	clk := new(Simulated)
+	clk.Run(50)
+	a := NewAlarm(clk)
+
+	a.Schedule(-1)
+	clk.Run(1) // needed to process timers
+	if !recv(a.C()) {
+		t.Fatal("Alarm did not fire for negative time")
+	}
+}
+
+func recv(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -18,6 +18,7 @@ package discover
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -28,7 +29,7 @@ import (
 // not need to be an actual node identifier.
 type lookup struct {
 	tab         *Table
-	queryfunc   func(*node) ([]*node, error)
+	queryfunc   queryFunc
 	replyCh     chan []*node
 	cancelCh    <-chan struct{}
 	asked, seen map[enode.ID]bool
@@ -139,32 +140,13 @@ func (it *lookup) slowdown() {
 }
 
 func (it *lookup) query(n *node, reply chan<- []*node) {
-	fails := it.tab.db.FindFails(n.ID(), n.IP())
 	r, err := it.queryfunc(n)
-	if err == errClosed {
-		// Avoid recording failures on shutdown.
-		reply <- nil
-		return
-	} else if len(r) == 0 {
-		fails++
-		it.tab.db.UpdateFindFails(n.ID(), n.IP(), fails)
-		// Remove the node from the local table if it fails to return anything useful too
-		// many times, but only if there are enough other nodes in the bucket.
-		dropped := false
-		if fails >= maxFindnodeFailures && it.tab.bucketLen(n.ID()) >= bucketSize/2 {
-			dropped = true
-			it.tab.delete(n)
+	if !errors.Is(err, errClosed) { // avoid recording failures on shutdown.
+		success := len(r) > 0
+		it.tab.trackRequest(n, success, r)
+		if err != nil {
+			it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "err", err)
 		}
-		it.tab.log.Trace("FINDNODE failed", "id", n.ID(), "failcount", fails, "dropped", dropped, "err", err)
-	} else if fails > 0 {
-		// Reset failure counter because it counts _consecutive_ failures.
-		it.tab.db.UpdateFindFails(n.ID(), n.IP(), 0)
-	}
-
-	// Grab as many nodes as possible. Some of them might not be alive anymore, but we'll
-	// just remove those again during revalidation.
-	for _, n := range r {
-		it.tab.addSeenNode(n)
 	}
 	reply <- r
 }

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -41,6 +41,7 @@ type BucketNode struct {
 // The fields of Node may not be modified.
 type node struct {
 	*enode.Node
+	revalList       *revalidationList
 	addedToTable    time.Time // first time node was added to bucket or replacement list
 	addedToBucket   time.Time // time it was added in the actual bucket
 	livenessChecks  uint      // how often liveness was checked

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -29,12 +29,22 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
+type BucketNode struct {
+	Node          *enode.Node `json:"node"`
+	AddedToTable  time.Time   `json:"addedToTable"`
+	AddedToBucket time.Time   `json:"addedToBucket"`
+	Checks        int         `json:"checks"`
+	Live          bool        `json:"live"`
+}
+
 // node represents a host on the network.
 // The fields of Node may not be modified.
 type node struct {
-	enode.Node
-	addedAt        time.Time // time when the node was added to the table
-	livenessChecks uint      // how often liveness was checked
+	*enode.Node
+	addedToTable    time.Time // first time node was added to bucket or replacement list
+	addedToBucket   time.Time // time it was added in the actual bucket
+	livenessChecks  uint      // how often liveness was checked
+	isValidatedLive bool      // true if existence of node is considered validated right now
 }
 
 type encPubkey [64]byte
@@ -65,7 +75,7 @@ func (e encPubkey) id() enode.ID {
 }
 
 func wrapNode(n *enode.Node) *node {
-	return &node{Node: *n}
+	return &node{Node: n}
 }
 
 func wrapNodes(ns []*enode.Node) []*node {
@@ -77,7 +87,7 @@ func wrapNodes(ns []*enode.Node) []*node {
 }
 
 func unwrapNode(n *node) *enode.Node {
-	return &n.Node
+	return n.Node
 }
 
 func unwrapNodes(ns []*node) []*enode.Node {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -572,8 +572,9 @@ func (tab *Table) handleAddNode(req addNodeOp) bool {
 	}
 
 	b := tab.bucket(req.node.ID())
-	if tab.bumpInBucket(b, req.node.Node) {
-		// Already in bucket, update record.
+	n, _ := tab.bumpInBucket(b, req.node.Node, req.isInbound)
+	if n != nil {
+		// Already in bucket.
 		return false
 	}
 	if len(b.entries) >= bucketSize {
@@ -664,26 +665,45 @@ func (tab *Table) deleteInBucket(b *bucket, id enode.ID) *node {
 	return rep
 }
 
-// bumpInBucket updates the node record of n in the bucket.
-func (tab *Table) bumpInBucket(b *bucket, newRecord *enode.Node) bool {
+// bumpInBucket updates a node record if it exists in the bucket.
+// The second return value reports whether the node's endpoint (IP/port) was updated.
+func (tab *Table) bumpInBucket(b *bucket, newRecord *enode.Node, isInbound bool) (n *node, endpointChanged bool) {
 	i := slices.IndexFunc(b.entries, func(elem *node) bool {
 		return elem.ID() == newRecord.ID()
 	})
 	if i == -1 {
-		return false
+		return nil, false // not in bucket
+	}
+	n = b.entries[i]
+
+	// For inbound updates (from the node itself) we accept any change, even if it sets
+	// back the sequence number. For found nodes (!isInbound), seq has to advance. Note
+	// this check also ensures found discv4 nodes (which always have seq=0) can't be
+	// updated.
+	if newRecord.Seq() <= n.Seq() && !isInbound {
+		return n, false
 	}
 
-	if !newRecord.IP().Equal(b.entries[i].IP()) {
-		// Endpoint has changed, ensure that the new IP fits into table limits.
-		tab.removeIP(b, b.entries[i].IP())
+	// Check endpoint update against IP limits.
+	ipchanged := newRecord.IPAddr() != n.IPAddr()
+	portchanged := newRecord.UDP() != n.UDP()
+	if ipchanged {
+		tab.removeIP(b, n.IP())
 		if !tab.addIP(b, newRecord.IP()) {
-			// It doesn't, put the previous one back.
-			tab.addIP(b, b.entries[i].IP())
-			return false
+			// It doesn't fit with the limit, put the previous record back.
+			tab.addIP(b, n.IP())
+			return n, false
 		}
 	}
-	b.entries[i].Node = newRecord
-	return true
+
+	// Apply update.
+	n.Node = newRecord
+	if ipchanged || portchanged {
+		// Ensure node is revalidated quickly for endpoint changes.
+		tab.revalidation.nodeEndpointChanged(tab, n)
+		return n, true
+	}
+	return n, false
 }
 
 func (tab *Table) handleTrackRequest(op trackRequestOp) {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -685,7 +685,7 @@ func (tab *Table) bumpInBucket(b *bucket, newRecord *enode.Node, isInbound bool)
 	}
 
 	// Check endpoint update against IP limits.
-	ipchanged := newRecord.IPAddr() != n.IPAddr()
+	ipchanged := !(net.IP.Equal(newRecord.IP(), n.IP()))
 	portchanged := newRecord.UDP() != n.UDP()
 	if ipchanged {
 		tab.removeIP(b, n.IP())

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -77,14 +77,18 @@ func (tr *tableRevalidation) nodeEndpointChanged(tab *Table, n *node) {
 // It returns the next time it should be invoked, which is used in the Table main loop
 // to schedule a timer. However, run can be called at any time.
 func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) (nextTime mclock.AbsTime) {
-	if n := tr.fast.get(now, &tab.rand, tr.activeReq); n != nil {
-		tr.startRequest(tab, n)
-		tr.fast.schedule(now, &tab.rand)
+	reval := func(list *revalidationList) {
+		if list.nextTime <= now {
+			if n := list.get(&tab.rand, tr.activeReq); n != nil {
+				tr.startRequest(tab, n)
+			}
+			// Update nextTime regardless if any requests were started because
+			// current value has passed.
+			list.schedule(now, &tab.rand)
+		}
 	}
-	if n := tr.slow.get(now, &tab.rand, tr.activeReq); n != nil {
-		tr.startRequest(tab, n)
-		tr.slow.schedule(now, &tab.rand)
-	}
+	reval(&tr.fast)
+	reval(&tr.slow)
 
 	return min(tr.fast.nextTime, tr.slow.nextTime)
 }
@@ -204,8 +208,8 @@ type revalidationList struct {
 }
 
 // get returns a random node from the queue. Nodes in the 'exclude' map are not returned.
-func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *node {
-	if now < list.nextTime || len(list.nodes) == 0 {
+func (list *revalidationList) get(rand randomSource, exclude map[enode.ID]struct{}) *node {
+	if len(list.nodes) == 0 {
 		return nil
 	}
 	for i := 0; i < len(list.nodes)*3; i++ {

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -1,0 +1,228 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+const never = mclock.AbsTime(math.MaxInt64)
+
+// tableRevalidation implements the node revalidation process.
+// It tracks all nodes contained in Table, and schedules sending PING to them.
+type tableRevalidation struct {
+	fast      revalidationList
+	slow      revalidationList
+	activeReq map[enode.ID]struct{}
+}
+
+type revalidationResponse struct {
+	n          *node
+	newRecord  *enode.Node
+	list       *revalidationList
+	didRespond bool
+}
+
+func (tr *tableRevalidation) init(cfg *Config) {
+	tr.activeReq = make(map[enode.ID]struct{})
+	tr.fast.nextTime = never
+	tr.fast.interval = cfg.PingInterval
+	tr.fast.name = "fast"
+	tr.slow.nextTime = never
+	tr.slow.interval = cfg.PingInterval * 3
+	tr.slow.name = "slow"
+}
+
+// nodeAdded is called when the table receives a new node.
+func (tr *tableRevalidation) nodeAdded(tab *Table, n *node) {
+	tr.fast.push(n, tab.cfg.Clock.Now(), &tab.rand)
+}
+
+// nodeRemoved is called when a node was removed from the table.
+func (tr *tableRevalidation) nodeRemoved(n *node) {
+	if !tr.fast.remove(n) {
+		tr.slow.remove(n)
+	}
+}
+
+// run performs node revalidation.
+// It returns the next time it should be invoked, which is used in the Table main loop
+// to schedule a timer. However, run can be called at any time.
+func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) (nextTime mclock.AbsTime) {
+	if n := tr.fast.get(now, &tab.rand, tr.activeReq); n != nil {
+		tr.startRequest(tab, &tr.fast, n)
+		tr.fast.schedule(now, &tab.rand)
+	}
+	if n := tr.slow.get(now, &tab.rand, tr.activeReq); n != nil {
+		tr.startRequest(tab, &tr.slow, n)
+		tr.slow.schedule(now, &tab.rand)
+	}
+
+	return min(tr.fast.nextTime, tr.slow.nextTime)
+}
+
+// startRequest spawns a revalidation request for node n.
+func (tr *tableRevalidation) startRequest(tab *Table, list *revalidationList, n *node) {
+	if _, ok := tr.activeReq[n.ID()]; ok {
+		panic(fmt.Errorf("duplicate startRequest (list %q, node %v)", list.name, n.ID()))
+	}
+	tr.activeReq[n.ID()] = struct{}{}
+	resp := revalidationResponse{n: n, list: list}
+
+	// Fetch the node while holding lock.
+	tab.mutex.Lock()
+	node := n.Node
+	tab.mutex.Unlock()
+
+	go tab.doRevalidate(resp, node)
+}
+
+func (tab *Table) doRevalidate(resp revalidationResponse, node *enode.Node) {
+	// Ping the selected node and wait for a pong response.
+	remoteSeq, err := tab.net.ping(node)
+	resp.didRespond = err == nil
+
+	// Also fetch record if the node replied and returned a higher sequence number.
+	if remoteSeq > node.Seq() {
+		newrec, err := tab.net.RequestENR(node)
+		if err != nil {
+			tab.log.Debug("ENR request failed", "id", node.ID(), "err", err)
+		} else {
+			resp.newRecord = newrec
+		}
+	}
+
+	select {
+	case tab.revalResponseCh <- resp:
+	case <-tab.closed:
+	}
+}
+
+// handleResponse processes the result of a revalidation request.
+func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationResponse) {
+	now := tab.cfg.Clock.Now()
+	n := resp.n
+	b := tab.bucket(n.ID())
+	delete(tr.activeReq, n.ID())
+
+	tab.mutex.Lock()
+	defer tab.mutex.Unlock()
+
+	if !resp.didRespond {
+		// Revalidation failed.
+		n.livenessChecks /= 3
+		if n.livenessChecks <= 0 {
+			tab.deleteInBucket(b, n.ID())
+		} else {
+			tr.moveToList(&tr.fast, resp.list, n, now, &tab.rand)
+		}
+		return
+	}
+
+	// The node responded.
+	n.livenessChecks++
+	n.isValidatedLive = true
+	var endpointChanged bool
+	if resp.newRecord != nil {
+		if tab.enrFilter != nil && !tab.enrFilter(resp.newRecord.Record()) {
+			tab.log.Trace("ENR record filter out", "id", n.ID())
+			tab.deleteInBucket(b, n.ID())
+			return
+		}
+		endpointChanged = tab.bumpInBucket(b, resp.newRecord)
+		if endpointChanged {
+			// If the node changed its advertised endpoint, the updated ENR is not served
+			// until it has been revalidated.
+			n.isValidatedLive = false
+		}
+	}
+	tab.log.Debug("Revalidated node", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", resp.list.name)
+
+	// Move node over to slow queue after first validation.
+	if !endpointChanged {
+		tr.moveToList(&tr.slow, resp.list, n, now, &tab.rand)
+	} else {
+		tr.moveToList(&tr.fast, resp.list, n, now, &tab.rand)
+	}
+
+	// Store potential seeds in database.
+	if n.isValidatedLive && n.livenessChecks > 5 {
+		tab.db.UpdateNode(resp.n.Node)
+	}
+}
+
+func (tr *tableRevalidation) moveToList(dest, source *revalidationList, n *node, now mclock.AbsTime, rand randomSource) {
+	if source == dest {
+		return
+	}
+	if !source.remove(n) {
+		panic(fmt.Errorf("moveToList(%q -> %q): node %v not in source list", source.name, dest.name, n.ID()))
+	}
+	dest.push(n, now, rand)
+}
+
+// revalidationList holds a list nodes and the next revalidation time.
+type revalidationList struct {
+	nodes    []*node
+	nextTime mclock.AbsTime
+	interval time.Duration
+	name     string
+}
+
+// get returns a random node from the queue. Nodes in the 'exclude' map are not returned.
+func (list *revalidationList) get(now mclock.AbsTime, rand randomSource, exclude map[enode.ID]struct{}) *node {
+	if now < list.nextTime || len(list.nodes) == 0 {
+		return nil
+	}
+	for i := 0; i < len(list.nodes)*3; i++ {
+		n := list.nodes[rand.Intn(len(list.nodes))]
+		_, excluded := exclude[n.ID()]
+		if !excluded {
+			return n
+		}
+	}
+	return nil
+}
+
+func (list *revalidationList) schedule(now mclock.AbsTime, rand randomSource) {
+	list.nextTime = now.Add(time.Duration(rand.Int63n(int64(list.interval))))
+}
+
+func (list *revalidationList) push(n *node, now mclock.AbsTime, rand randomSource) {
+	list.nodes = append(list.nodes, n)
+	if list.nextTime == never {
+		list.schedule(now, rand)
+	}
+}
+
+func (list *revalidationList) remove(n *node) bool {
+	i := slices.Index(list.nodes, n)
+	if i == -1 {
+		return false
+	}
+	list.nodes = slices.Delete(list.nodes, i, i+1)
+	if len(list.nodes) == 0 {
+		list.nextTime = never
+	}
+	return true
+}

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -28,6 +28,8 @@ import (
 
 const never = mclock.AbsTime(math.MaxInt64)
 
+const slowRevalidationFactor = 3
+
 // tableRevalidation implements the node revalidation process.
 // It tracks all nodes contained in Table, and schedules sending PING to them.
 type tableRevalidation struct {
@@ -48,7 +50,7 @@ func (tr *tableRevalidation) init(cfg *Config) {
 	tr.fast.interval = cfg.PingInterval
 	tr.fast.name = "fast"
 	tr.slow.nextTime = never
-	tr.slow.interval = cfg.PingInterval * 3
+	tr.slow.interval = cfg.PingInterval * slowRevalidationFactor
 	tr.slow.name = "slow"
 }
 
@@ -63,6 +65,12 @@ func (tr *tableRevalidation) nodeRemoved(n *node) {
 		panic(fmt.Errorf("removed node %v has nil revalList", n.ID()))
 	}
 	n.revalList.remove(n)
+}
+
+// nodeEndpointChanged is called when a change in IP or port is detected.
+func (tr *tableRevalidation) nodeEndpointChanged(tab *Table, n *node) {
+	n.isValidatedLive = false
+	tr.moveToList(&tr.fast, n, tab.cfg.Clock.Now(), &tab.rand)
 }
 
 // run performs node revalidation.
@@ -146,11 +154,11 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	defer tab.mutex.Unlock()
 
 	if !resp.didRespond {
-		// Revalidation failed.
 		n.livenessChecks /= 3
 		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
 		} else {
+			tab.log.Debug("Node revalidation failed", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
 			tr.moveToList(&tr.fast, n, now, &tab.rand)
 		}
 		return
@@ -159,6 +167,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 	// The node responded.
 	n.livenessChecks++
 	n.isValidatedLive = true
+	tab.log.Debug("Node revalidated", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList.name)
 	var endpointChanged bool
 	if resp.newRecord != nil {
 		if tab.enrFilter != nil && !tab.enrFilter(resp.newRecord.Record()) {
@@ -166,20 +175,12 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 			tab.deleteInBucket(b, n.ID())
 			return
 		}
-		endpointChanged = tab.bumpInBucket(b, resp.newRecord)
-		if endpointChanged {
-			// If the node changed its advertised endpoint, the updated ENR is not served
-			// until it has been revalidated.
-			n.isValidatedLive = false
-		}
+		_, endpointChanged = tab.bumpInBucket(b, resp.newRecord, false)
 	}
-	tab.log.Debug("Revalidated node", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList)
 
-	// Move node over to slow queue after first validation.
+	// Node moves to slow list if it passed and hasn't changed.
 	if !endpointChanged {
 		tr.moveToList(&tr.slow, n, now, &tab.rand)
-	} else {
-		tr.moveToList(&tr.fast, n, now, &tab.rand)
 	}
 }
 

--- a/p2p/discover/table_reval.go
+++ b/p2p/discover/table_reval.go
@@ -39,7 +39,6 @@ type tableRevalidation struct {
 type revalidationResponse struct {
 	n          *node
 	newRecord  *enode.Node
-	list       *revalidationList
 	didRespond bool
 }
 
@@ -60,9 +59,10 @@ func (tr *tableRevalidation) nodeAdded(tab *Table, n *node) {
 
 // nodeRemoved is called when a node was removed from the table.
 func (tr *tableRevalidation) nodeRemoved(n *node) {
-	if !tr.fast.remove(n) {
-		tr.slow.remove(n)
+	if n.revalList == nil {
+		panic(fmt.Errorf("removed node %v has nil revalList", n.ID()))
 	}
+	n.revalList.remove(n)
 }
 
 // run performs node revalidation.
@@ -70,11 +70,11 @@ func (tr *tableRevalidation) nodeRemoved(n *node) {
 // to schedule a timer. However, run can be called at any time.
 func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) (nextTime mclock.AbsTime) {
 	if n := tr.fast.get(now, &tab.rand, tr.activeReq); n != nil {
-		tr.startRequest(tab, &tr.fast, n)
+		tr.startRequest(tab, n)
 		tr.fast.schedule(now, &tab.rand)
 	}
 	if n := tr.slow.get(now, &tab.rand, tr.activeReq); n != nil {
-		tr.startRequest(tab, &tr.slow, n)
+		tr.startRequest(tab, n)
 		tr.slow.schedule(now, &tab.rand)
 	}
 
@@ -82,12 +82,12 @@ func (tr *tableRevalidation) run(tab *Table, now mclock.AbsTime) (nextTime mcloc
 }
 
 // startRequest spawns a revalidation request for node n.
-func (tr *tableRevalidation) startRequest(tab *Table, list *revalidationList, n *node) {
+func (tr *tableRevalidation) startRequest(tab *Table, n *node) {
 	if _, ok := tr.activeReq[n.ID()]; ok {
-		panic(fmt.Errorf("duplicate startRequest (list %q, node %v)", list.name, n.ID()))
+		panic(fmt.Errorf("duplicate startRequest (node %v)", n.ID()))
 	}
 	tr.activeReq[n.ID()] = struct{}{}
-	resp := revalidationResponse{n: n, list: list}
+	resp := revalidationResponse{n: n}
 
 	// Fetch the node while holding lock.
 	tab.mutex.Lock()
@@ -120,11 +120,28 @@ func (tab *Table) doRevalidate(resp revalidationResponse, node *enode.Node) {
 
 // handleResponse processes the result of a revalidation request.
 func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationResponse) {
-	now := tab.cfg.Clock.Now()
-	n := resp.n
-	b := tab.bucket(n.ID())
+	var (
+		now = tab.cfg.Clock.Now()
+		n   = resp.n
+		b   = tab.bucket(n.ID())
+	)
 	delete(tr.activeReq, n.ID())
 
+	// If the node was removed from the table while getting checked, we need to stop
+	// processing here to avoid re-adding it.
+	if n.revalList == nil {
+		return
+	}
+
+	// Store potential seeds in database.
+	// This is done via defer to avoid holding Table lock while writing to DB.
+	defer func() {
+		if n.isValidatedLive && n.livenessChecks > 5 {
+			tab.db.UpdateNode(resp.n.Node)
+		}
+	}()
+
+	// Remaining logic needs access to Table internals.
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 
@@ -134,7 +151,7 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 		if n.livenessChecks <= 0 {
 			tab.deleteInBucket(b, n.ID())
 		} else {
-			tr.moveToList(&tr.fast, resp.list, n, now, &tab.rand)
+			tr.moveToList(&tr.fast, n, now, &tab.rand)
 		}
 		return
 	}
@@ -156,27 +173,23 @@ func (tr *tableRevalidation) handleResponse(tab *Table, resp revalidationRespons
 			n.isValidatedLive = false
 		}
 	}
-	tab.log.Debug("Revalidated node", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", resp.list.name)
+	tab.log.Debug("Revalidated node", "b", b.index, "id", n.ID(), "checks", n.livenessChecks, "q", n.revalList)
 
 	// Move node over to slow queue after first validation.
 	if !endpointChanged {
-		tr.moveToList(&tr.slow, resp.list, n, now, &tab.rand)
+		tr.moveToList(&tr.slow, n, now, &tab.rand)
 	} else {
-		tr.moveToList(&tr.fast, resp.list, n, now, &tab.rand)
-	}
-
-	// Store potential seeds in database.
-	if n.isValidatedLive && n.livenessChecks > 5 {
-		tab.db.UpdateNode(resp.n.Node)
+		tr.moveToList(&tr.fast, n, now, &tab.rand)
 	}
 }
 
-func (tr *tableRevalidation) moveToList(dest, source *revalidationList, n *node, now mclock.AbsTime, rand randomSource) {
-	if source == dest {
+// moveToList ensures n is in the 'dest' list.
+func (tr *tableRevalidation) moveToList(dest *revalidationList, n *node, now mclock.AbsTime, rand randomSource) {
+	if n.revalList == dest {
 		return
 	}
-	if !source.remove(n) {
-		panic(fmt.Errorf("moveToList(%q -> %q): node %v not in source list", source.name, dest.name, n.ID()))
+	if n.revalList != nil {
+		n.revalList.remove(n)
 	}
 	dest.push(n, now, rand)
 }
@@ -213,16 +226,23 @@ func (list *revalidationList) push(n *node, now mclock.AbsTime, rand randomSourc
 	if list.nextTime == never {
 		list.schedule(now, rand)
 	}
+	n.revalList = list
 }
 
-func (list *revalidationList) remove(n *node) bool {
+func (list *revalidationList) remove(n *node) {
 	i := slices.Index(list.nodes, n)
 	if i == -1 {
-		return false
+		panic(fmt.Errorf("node %v not found in list", n.ID()))
 	}
 	list.nodes = slices.Delete(list.nodes, i, i+1)
 	if len(list.nodes) == 0 {
 		list.nextTime = never
 	}
-	return true
+	n.revalList = nil
+}
+
+func (list *revalidationList) contains(id enode.ID) bool {
+	return slices.ContainsFunc(list.nodes, func(n *node) bool {
+		return n.ID() == id
+	})
 }

--- a/p2p/discover/table_reval_test.go
+++ b/p2p/discover/table_reval_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+)
+
+// This test checks that revalidation can handle a node disappearing while
+// a request is active.
+func TestRevalidationNodeRemoved(t *testing.T) {
+	var (
+		clock     mclock.Simulated
+		transport = newPingRecorder()
+		tab, db   = newInactiveTestTable(transport, Config{Clock: &clock})
+		tr        = &tab.revalidation
+	)
+	defer db.Close()
+
+	// Fill a bucket.
+	node := nodeAtDistance(tab.self().ID(), 255, net.IP{77, 88, 99, 1})
+	tab.handleAddNode(addNodeOp{node: node})
+
+	// Start a revalidation request. Schedule once to get the next start time,
+	// then advance the clock to that point and schedule again to start.
+	next := tr.run(tab, clock.Now())
+	clock.Run(time.Duration(next + 1))
+	tr.run(tab, clock.Now())
+	if len(tr.activeReq) != 1 {
+		t.Fatal("revalidation request did not start:", tr.activeReq)
+	}
+
+	// Delete the node.
+	tab.deleteInBucket(tab.bucket(node.ID()), node.ID())
+
+	// Now finish the revalidation request.
+	var resp revalidationResponse
+	select {
+	case resp = <-tab.revalResponseCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for revalidation")
+	}
+	tr.handleResponse(tab, resp)
+
+	// Ensure the node was not re-added to the table.
+	if tab.getNode(node.ID()) != nil {
+		t.Fatal("node was re-added to Table")
+	}
+	if tr.fast.contains(node.ID()) || tr.slow.contains(node.ID()) {
+		t.Fatal("removed node contained in revalidation list")
+	}
+}

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -20,20 +20,19 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
-
 	"net"
 	"reflect"
 	"testing"
 	"testing/quick"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/internal/testlog"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func TestTable_pingReplace(t *testing.T) {
@@ -52,106 +51,109 @@ func TestTable_pingReplace(t *testing.T) {
 }
 
 func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding bool) {
+	simclock := new(mclock.Simulated)
 	transport := newPingRecorder()
-	tab, db := newTestTable(transport)
+	tab, db := newTestTable(transport, Config{
+		Clock: simclock,
+		Log:   testlog.Logger(t, log.LvlTrace),
+	})
 	defer db.Close()
 	defer tab.close()
 
 	<-tab.initDone
 
 	// Fill up the sender's bucket.
-	pingKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
-	pingSender := wrapNode(enode.NewV4(&pingKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99))
-	last := fillBucket(tab, pingSender)
+	replacementNodeKey, _ := crypto.HexToECDSA("45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8")
+	replacementNode := wrapNode(enode.NewV4(&replacementNodeKey.PublicKey, net.IP{127, 0, 0, 1}, 99, 99))
+	last := fillBucket(tab, replacementNode.ID())
+	tab.mutex.Lock()
+	nodeEvents := newNodeEventRecorder(128)
+	tab.nodeAddedHook = nodeEvents.nodeAdded
+	tab.nodeRemovedHook = nodeEvents.nodeRemoved
+	tab.mutex.Unlock()
 
-	// Add the sender as if it just pinged us. Revalidate should replace the last node in
-	// its bucket if it is unresponsive. Revalidate again to ensure that
+	// The revalidation process should replace
+	// this node in the bucket if it is unresponsive.
 	transport.dead[last.ID()] = !lastInBucketIsResponding
-	transport.dead[pingSender.ID()] = !newNodeIsResponding
-	tab.addSeenNodeSync(pingSender)
-	tab.doRevalidate(make(chan struct{}, 1))
-	tab.doRevalidate(make(chan struct{}, 1))
+	transport.dead[replacementNode.ID()] = !newNodeIsResponding
 
-	if !transport.pinged[last.ID()] {
-		// Oldest node in bucket is pinged to see whether it is still alive.
-		t.Error("table did not ping last node in bucket")
+	// Add replacement node to table.
+	tab.addFoundNode(replacementNode)
+
+	t.Log("last:", last.ID())
+	t.Log("replacement:", replacementNode.ID())
+
+	// Wait until the last node was pinged.
+	waitForRevalidationPing(t, transport, tab, last.ID())
+
+	if !lastInBucketIsResponding {
+		if !nodeEvents.waitNodeAbsent(last.ID(), 2*time.Second) {
+			t.Error("last node was not removed")
+		}
+		if !nodeEvents.waitNodePresent(replacementNode.ID(), 2*time.Second) {
+			t.Error("replacement node was not added")
+		}
+
+		// If a replacement is expected, we also need to wait until the replacement node
+		// was pinged and added/removed.
+		waitForRevalidationPing(t, transport, tab, replacementNode.ID())
+		if !newNodeIsResponding {
+			if !nodeEvents.waitNodeAbsent(replacementNode.ID(), 2*time.Second) {
+				t.Error("replacement node was not removed")
+			}
+		}
 	}
 
+	// Check bucket content.
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 	wantSize := bucketSize
 	if !lastInBucketIsResponding && !newNodeIsResponding {
 		wantSize--
 	}
-	if l := len(tab.bucket(pingSender.ID()).entries); l != wantSize {
-		t.Errorf("wrong bucket size after bond: got %d, want %d", l, wantSize)
+	bucket := tab.bucket(replacementNode.ID())
+	if l := len(bucket.entries); l != wantSize {
+		t.Errorf("wrong bucket size after revalidation: got %d, want %d", l, wantSize)
 	}
-	if found := contains(tab.bucket(pingSender.ID()).entries, last.ID()); found != lastInBucketIsResponding {
-		t.Errorf("last entry found: %t, want: %t", found, lastInBucketIsResponding)
+	if ok := contains(bucket.entries, last.ID()); ok != lastInBucketIsResponding {
+		t.Errorf("revalidated node found: %t, want: %t", ok, lastInBucketIsResponding)
 	}
 	wantNewEntry := newNodeIsResponding && !lastInBucketIsResponding
-	if found := contains(tab.bucket(pingSender.ID()).entries, pingSender.ID()); found != wantNewEntry {
-		t.Errorf("new entry found: %t, want: %t", found, wantNewEntry)
+	if ok := contains(bucket.entries, replacementNode.ID()); ok != wantNewEntry {
+		t.Errorf("replacement node found: %t, want: %t", ok, wantNewEntry)
 	}
 }
 
-func TestBucket_bumpNoDuplicates(t *testing.T) {
-	t.Parallel()
-	cfg := &quick.Config{
-		MaxCount: 1000,
-		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
-		Values: func(args []reflect.Value, rand *rand.Rand) {
-			// generate a random list of nodes. this will be the content of the bucket.
-			n := rand.Intn(bucketSize-1) + 1
-			nodes := make([]*node, n)
-			for i := range nodes {
-				nodes[i] = nodeAtDistance(enode.ID{}, 200, intIP(200))
-			}
-			args[0] = reflect.ValueOf(nodes)
-			// generate random bump positions.
-			bumps := make([]int, rand.Intn(100))
-			for i := range bumps {
-				bumps[i] = rand.Intn(len(nodes))
-			}
-			args[1] = reflect.ValueOf(bumps)
-		},
-	}
+// waitForRevalidationPing waits until a PING message is sent to a node with the given id.
+func waitForRevalidationPing(t *testing.T, transport *pingRecorder, tab *Table, id enode.ID) *enode.Node {
+	t.Helper()
 
-	prop := func(nodes []*node, bumps []int) (ok bool) {
-		tab, db := newTestTable(newPingRecorder())
-		defer db.Close()
-		defer tab.close()
-
-		b := &bucket{entries: make([]*node, len(nodes))}
-		copy(b.entries, nodes)
-		for i, pos := range bumps {
-			tab.bumpInBucket(b, b.entries[pos])
-			if hasDuplicates(b.entries) {
-				t.Logf("bucket has duplicates after %d/%d bumps:", i+1, len(bumps))
-				for _, n := range b.entries {
-					t.Logf("  %p", n)
-				}
-				return false
-			}
+	simclock := tab.cfg.Clock.(*mclock.Simulated)
+	maxAttempts := tab.len() * 8
+	for i := 0; i < maxAttempts; i++ {
+		simclock.Run(tab.cfg.PingInterval)
+		p := transport.waitPing(2 * time.Second)
+		if p == nil {
+			t.Fatal("Table did not send revalidation ping")
 		}
-		checkIPLimitInvariant(t, tab)
-		return true
+		if id == (enode.ID{}) || p.ID() == id {
+			return p
+		}
 	}
-	if err := quick.Check(prop, cfg); err != nil {
-		t.Error(err)
-	}
+	t.Fatalf("Table did not ping node %v (%d attempts)", id, maxAttempts)
+	return nil
 }
 
 // This checks that the table-wide IP limit is applied correctly.
 func TestTable_IPLimit(t *testing.T) {
 	transport := newPingRecorder()
-	tab, db := newTestTable(transport)
+	tab, db := newTestTable(transport, Config{})
 	defer db.Close()
 	defer tab.close()
 
 	for i := 0; i < tableIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNodeSync(n)
+		tab.addFoundNode(n)
 	}
 	if tab.len() > tableIPLimit {
 		t.Errorf("too many nodes in table")
@@ -162,14 +164,14 @@ func TestTable_IPLimit(t *testing.T) {
 // This checks that the per-bucket IP limit is applied correctly.
 func TestTable_BucketIPLimit(t *testing.T) {
 	transport := newPingRecorder()
-	tab, db := newTestTable(transport)
+	tab, db := newTestTable(transport, Config{})
 	defer db.Close()
 	defer tab.close()
 
 	d := 3
 	for i := 0; i < bucketIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), d, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNodeSync(n)
+		tab.addFoundNode(n)
 	}
 	if tab.len() > bucketIPLimit {
 		t.Errorf("too many nodes in table")
@@ -199,10 +201,10 @@ func TestTable_findnodeByID(t *testing.T) {
 	test := func(test *closeTest) bool {
 		// for any node table, Target and N
 		transport := newPingRecorder()
-		tab, db := newTestTable(transport)
+		tab, db := newTestTable(transport, Config{})
 		defer db.Close()
 		defer tab.close()
-		fillTable(tab, test.All)
+		fillTable(tab, test.All, true)
 
 		// check that closest(Target, N) returns nodes
 		result := tab.findnodeByID(test.Target, test.N, false).entries
@@ -250,41 +252,6 @@ func TestTable_findnodeByID(t *testing.T) {
 	}
 }
 
-func TestTable_ReadRandomNodesGetAll(t *testing.T) {
-	cfg := &quick.Config{
-		MaxCount: 200,
-		Rand:     rand.New(rand.NewSource(time.Now().Unix())),
-		Values: func(args []reflect.Value, rand *rand.Rand) {
-			args[0] = reflect.ValueOf(make([]*enode.Node, rand.Intn(1000)))
-		},
-	}
-	test := func(buf []*enode.Node) bool {
-		transport := newPingRecorder()
-		tab, db := newTestTable(transport)
-		defer db.Close()
-		defer tab.close()
-		<-tab.initDone
-
-		for i := 0; i < len(buf); i++ {
-			ld := cfg.Rand.Intn(len(tab.buckets))
-			fillTable(tab, []*node{nodeAtDistance(tab.self().ID(), ld, intIP(ld))})
-		}
-		gotN := tab.ReadRandomNodes(buf)
-		if gotN != tab.len() {
-			t.Errorf("wrong number of nodes, got %d, want %d", gotN, tab.len())
-			return false
-		}
-		if hasDuplicates(wrapNodes(buf[:gotN])) {
-			t.Errorf("result contains duplicates")
-			return false
-		}
-		return true
-	}
-	if err := quick.Check(test, cfg); err != nil {
-		t.Error(err)
-	}
-}
-
 type closeTest struct {
 	Self   enode.ID
 	Target enode.ID
@@ -309,7 +276,7 @@ func (*closeTest) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 func TestTable_addVerifiedNode(t *testing.T) {
-	tab, db := newTestTable(newPingRecorder())
+	tab, db := newTestTable(newPingRecorder(), Config{})
 	<-tab.initDone
 	defer db.Close()
 	defer tab.close()
@@ -317,31 +284,32 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNodeSync(n1)
-	tab.addSeenNodeSync(n2)
+	tab.addFoundNode(n1)
+	tab.addFoundNode(n2)
+	bucket := tab.bucket(n1.ID())
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
-		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
+	if !reflect.DeepEqual(unwrapNodes(bucket.entries), unwrapNodes(bcontent)) {
+		t.Fatalf("wrong bucket content: %v", bucket.entries)
 	}
 
 	// Add a changed version of n2.
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addVerifiedNodeSync(newn2)
+	tab.addInboundNodeSync(newn2)
 
 	// Check that bucket is updated correctly.
-	newBcontent := []*node{newn2, n1}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, newBcontent) {
-		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
+	newBcontent := []*node{n1, newn2}
+	if !reflect.DeepEqual(unwrapNodes(bucket.entries), unwrapNodes(newBcontent)) {
+		t.Fatalf("wrong bucket content after update: %v", bucket.entries)
 	}
 	checkIPLimitInvariant(t, tab)
 }
 
 func TestTable_addSeenNode(t *testing.T) {
-	tab, db := newTestTable(newPingRecorder())
+	tab, db := newTestTable(newPingRecorder(), Config{})
 	<-tab.initDone
 	defer db.Close()
 	defer tab.close()
@@ -349,8 +317,8 @@ func TestTable_addSeenNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNodeSync(n1)
-	tab.addSeenNodeSync(n2)
+	tab.addFoundNode(n1)
+	tab.addFoundNode(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -362,7 +330,7 @@ func TestTable_addSeenNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addSeenNodeSync(newn2)
+	tab.addFoundNode(newn2)
 
 	// Check that bucket content is unchanged.
 	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
@@ -375,7 +343,10 @@ func TestTable_addSeenNode(t *testing.T) {
 // announces a new sequence number, the new record should be pulled.
 func TestTable_revalidateSyncRecord(t *testing.T) {
 	transport := newPingRecorder()
-	tab, db := newTestTable(transport)
+	tab, db := newTestTable(transport, Config{
+		Clock: new(mclock.Simulated),
+		Log:   testlog.Logger(t, log.LvlTrace),
+	})
 	<-tab.initDone
 	defer db.Close()
 	defer tab.close()
@@ -385,53 +356,75 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
 	id := enode.ID{1}
 	n1 := wrapNode(enode.SignNull(&r, id))
-	tab.addSeenNodeSync(n1)
+	tab.addFoundNode(n1)
 
 	// Update the node record.
 	r.Set(enr.WithEntry("foo", "bar"))
 	n2 := enode.SignNull(&r, id)
 	transport.updateRecord(n2)
 
-	tab.doRevalidate(make(chan struct{}, 1))
+	// Wait for revalidation. We wait for the node to be revalidated two times
+	// in order to synchronize with the update in the able.
+	waitForRevalidationPing(t, transport, tab, n2.ID())
+	waitForRevalidationPing(t, transport, tab, n2.ID())
+
 	intable := tab.getNode(id)
 	if !reflect.DeepEqual(intable, n2) {
 		t.Fatalf("table contains old record with seq %d, want seq %d", intable.Seq(), n2.Seq())
 	}
 }
 
-// This test checks that ENR filtering is working properly
-func TestTable_filterNode(t *testing.T) {
-	// Create ENR filter
-	type eth struct {
-		ForkID forkid.ID
-		Tail   []rlp.RawValue `rlp:"tail"`
+func TestNodesPush(t *testing.T) {
+	var target enode.ID
+	n1 := nodeAtDistance(target, 255, intIP(1))
+	n2 := nodeAtDistance(target, 254, intIP(2))
+	n3 := nodeAtDistance(target, 253, intIP(3))
+	perm := [][]*node{
+		{n3, n2, n1},
+		{n3, n1, n2},
+		{n2, n3, n1},
+		{n2, n1, n3},
+		{n1, n3, n2},
+		{n1, n2, n3},
 	}
 
-	enrFilter, _ := ParseEthFilter("ronin-mainnet")
-
-	// Check test ENR record
-	var r1 enr.Record
-	r1.Set(enr.WithEntry("foo", "bar"))
-	if enrFilter(&r1) {
-		t.Fatalf("filterNode doesn't work correctly for entry")
+	// Insert all permutations into lists with size limit 3.
+	for _, nodes := range perm {
+		list := nodesByDistance{target: target}
+		for _, n := range nodes {
+			list.push(n, 3)
+		}
+		if !slicesEqual(list.entries, perm[0], nodeIDEqual) {
+			t.Fatal("not equal")
+		}
 	}
-	t.Logf("Check test ENR record - passed")
 
-	// Check wrong genesis ENR record
-	var r2 enr.Record
-	r2.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.RoninMainnetChainConfig, params.RoninTestnetGenesisHash, uint64(0))}))
-	if enrFilter(&r2) {
-		t.Fatalf("filterNode doesn't work correctly for wrong genesis entry")
+	// Insert all permutations into lists with size limit 2.
+	for _, nodes := range perm {
+		list := nodesByDistance{target: target}
+		for _, n := range nodes {
+			list.push(n, 2)
+		}
+		if !slicesEqual(list.entries, perm[0][:2], nodeIDEqual) {
+			t.Fatal("not equal")
+		}
 	}
-	t.Logf("Check wrong genesis ENR record - passed")
+}
 
-	// Check correct genesis ENR record
-	var r3 enr.Record
-	r3.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.RoninMainnetChainConfig, params.RoninMainnetGenesisHash, uint64(0))}))
-	if !enrFilter(&r3) {
-		t.Fatalf("filterNode doesn't work correctly for correct genesis entry")
+func nodeIDEqual(n1, n2 *node) bool {
+	return n1.ID() == n2.ID()
+}
+
+func slicesEqual[T any](s1, s2 []T, check func(e1, e2 T) bool) bool {
+	if len(s1) != len(s2) {
+		return false
 	}
-	t.Logf("Check correct genesis ENR record - passed")
+	for i := range s1 {
+		if !check(s1[i], s2[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // gen wraps quick.Value so it's easier to use.

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -131,7 +131,7 @@ func waitForRevalidationPing(t *testing.T, transport *pingRecorder, tab *Table, 
 	simclock := tab.cfg.Clock.(*mclock.Simulated)
 	maxAttempts := tab.len() * 8
 	for i := 0; i < maxAttempts; i++ {
-		simclock.Run(tab.cfg.PingInterval)
+		simclock.Run(tab.cfg.PingInterval * slowRevalidationFactor)
 		p := transport.waitPing(2 * time.Second)
 		if p == nil {
 			t.Fatal("Table did not send revalidation ping")
@@ -275,7 +275,7 @@ func (*closeTest) Generate(rand *rand.Rand, size int) reflect.Value {
 	return reflect.ValueOf(t)
 }
 
-func TestTable_addVerifiedNode(t *testing.T) {
+func TestTable_addInboundNode(t *testing.T) {
 	tab, db := newTestTable(newPingRecorder(), Config{})
 	<-tab.initDone
 	defer db.Close()
@@ -286,29 +286,26 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
 	tab.addFoundNode(n1)
 	tab.addFoundNode(n2)
-	bucket := tab.bucket(n1.ID())
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2.Node})
 
-	// Verify bucket content:
-	bcontent := []*node{n1, n2}
-	if !reflect.DeepEqual(unwrapNodes(bucket.entries), unwrapNodes(bcontent)) {
-		t.Fatalf("wrong bucket content: %v", bucket.entries)
-	}
-
-	// Add a changed version of n2.
+	// Add a changed version of n2. The bucket should be updated.
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
-	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addInboundNodeSync(newn2)
+	n2v2 := enode.SignNull(newrec, n2.ID())
+	tab.addInboundNodeSync(wrapNode(n2v2))
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
 
-	// Check that bucket is updated correctly.
-	newBcontent := []*node{n1, newn2}
-	if !reflect.DeepEqual(unwrapNodes(bucket.entries), unwrapNodes(newBcontent)) {
-		t.Fatalf("wrong bucket content after update: %v", bucket.entries)
-	}
-	checkIPLimitInvariant(t, tab)
+	// Try updating n2 without sequence number change. The update is accepted
+	// because it's inbound.
+	newrec = n2.Record()
+	newrec.Set(enr.IP{100, 100, 100, 100})
+	newrec.SetSeq(n2.Seq())
+	n2v3 := enode.SignNull(newrec, n2.ID())
+	tab.addInboundNodeSync(wrapNode(n2v3))
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v3})
 }
 
-func TestTable_addSeenNode(t *testing.T) {
+func TestTable_addFoundNode(t *testing.T) {
 	tab, db := newTestTable(newPingRecorder(), Config{})
 	<-tab.initDone
 	defer db.Close()
@@ -319,23 +316,84 @@ func TestTable_addSeenNode(t *testing.T) {
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
 	tab.addFoundNode(n1)
 	tab.addFoundNode(n2)
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2.Node})
 
-	// Verify bucket content:
-	bcontent := []*node{n1, n2}
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
-		t.Fatalf("wrong bucket content: %v", tab.bucket(n1.ID()).entries)
-	}
-
-	// Add a changed version of n2.
+	// Add a changed version of n2. The bucket should be updated.
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
-	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addFoundNode(newn2)
+	n2v2 := enode.SignNull(newrec, n2.ID())
+	tab.addFoundNode(wrapNode(n2v2))
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
 
-	// Check that bucket content is unchanged.
-	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
-		t.Fatalf("wrong bucket content after update: %v", tab.bucket(n1.ID()).entries)
+	// Try updating n2 without a sequence number change.
+	// The update should not be accepted.
+	newrec = n2.Record()
+	newrec.Set(enr.IP{100, 100, 100, 100})
+	newrec.SetSeq(n2.Seq())
+	n2v3 := enode.SignNull(newrec, n2.ID())
+	tab.addFoundNode(wrapNode(n2v3))
+	checkBucketContent(t, tab, []*enode.Node{n1.Node, n2v2})
+}
+
+// This test checks that discv4 nodes can update their own endpoint via PING.
+func TestTable_addInboundNodeUpdateV4Accept(t *testing.T) {
+	tab, db := newTestTable(newPingRecorder(), Config{})
+	<-tab.initDone
+	defer db.Close()
+	defer tab.close()
+
+	// Add a v4 node.
+	key, _ := crypto.HexToECDSA("dd3757a8075e88d0f2b1431e7d3c5b1562e1c0aab9643707e8cbfcc8dae5cfe3")
+	n1 := enode.NewV4(&key.PublicKey, net.IP{88, 77, 66, 1}, 9000, 9000)
+	tab.addInboundNodeSync(wrapNode(n1))
+	checkBucketContent(t, tab, []*enode.Node{n1})
+
+	// Add an updated version with changed IP.
+	// The update will be accepted because it is inbound.
+	n1v2 := enode.NewV4(&key.PublicKey, net.IP{99, 99, 99, 99}, 9000, 9000)
+	tab.addInboundNodeSync(wrapNode(n1v2))
+	checkBucketContent(t, tab, []*enode.Node{n1v2})
+}
+
+// This test checks that discv4 node entries will NOT be updated when a
+// changed record is found.
+func TestTable_addFoundNodeV4UpdateReject(t *testing.T) {
+	tab, db := newTestTable(newPingRecorder(), Config{})
+	<-tab.initDone
+	defer db.Close()
+	defer tab.close()
+
+	// Add a v4 node.
+	key, _ := crypto.HexToECDSA("dd3757a8075e88d0f2b1431e7d3c5b1562e1c0aab9643707e8cbfcc8dae5cfe3")
+	n1 := enode.NewV4(&key.PublicKey, net.IP{88, 77, 66, 1}, 9000, 9000)
+	tab.addFoundNode(wrapNode(n1))
+	checkBucketContent(t, tab, []*enode.Node{n1})
+
+	// Add an updated version with changed IP.
+	// The update won't be accepted because it isn't inbound.
+	n1v2 := enode.NewV4(&key.PublicKey, net.IP{99, 99, 99, 99}, 9000, 9000)
+	tab.addFoundNode(wrapNode(n1v2))
+	checkBucketContent(t, tab, []*enode.Node{n1})
+}
+
+func checkBucketContent(t *testing.T, tab *Table, nodes []*enode.Node) {
+	t.Helper()
+
+	b := tab.bucket(nodes[0].ID())
+	if reflect.DeepEqual(unwrapNodes(b.entries), nodes) {
+		return
 	}
+	t.Log("wrong bucket content. have nodes:")
+	for _, n := range b.entries {
+		t.Logf("  %v (seq=%v, ip=%v)", n.ID(), n.Seq(), n.IP())
+	}
+	t.Log("want nodes:")
+	for _, n := range nodes {
+		t.Logf("  %v (seq=%v, ip=%v)", n.ID(), n.Seq(), n.IP())
+	}
+	t.FailNow()
+
+	// Also check IP limits.
 	checkIPLimitInvariant(t, tab)
 }
 

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -43,9 +43,15 @@ func init() {
 }
 
 func newTestTable(t transport, cfg Config) (*Table, *enode.DB) {
+	tab, db := newInactiveTestTable(t, cfg)
+	go tab.loop()
+	return tab, db
+}
+
+// newInactiveTestTable creates a Table without running the main loop.
+func newInactiveTestTable(t transport, cfg Config) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
 	tab, _ := newTable(t, db, cfg)
-	go tab.loop()
 	return tab, db
 }
 

--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -40,7 +40,7 @@ func TestUDPv4_Lookup(t *testing.T) {
 	}
 
 	// Seed table with initial node.
-	fillTable(test.table, []*node{wrapNode(lookupTestnet.node(256, 0))})
+	fillTable(test.table, []*node{wrapNode(lookupTestnet.node(256, 0))}, true)
 
 	// Start the lookup.
 	resultC := make(chan []*enode.Node, 1)
@@ -74,7 +74,7 @@ func TestUDPv4_LookupIterator(t *testing.T) {
 	for i := range lookupTestnet.dists[256] {
 		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
 	}
-	fillTable(test.table, bootnodes)
+	fillTable(test.table, bootnodes, true)
 	go serveTestnet(test, lookupTestnet)
 
 	// Create the iterator and collect the nodes it yields.
@@ -109,7 +109,7 @@ func TestUDPv4_LookupIteratorClose(t *testing.T) {
 	for i := range lookupTestnet.dists[256] {
 		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
 	}
-	fillTable(test.table, bootnodes)
+	fillTable(test.table, bootnodes, true)
 	go serveTestnet(test, lookupTestnet)
 
 	it := test.udp.RandomNodes()

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -270,7 +270,7 @@ func TestUDPv4_findnode(t *testing.T) {
 		}
 		nodes.push(n, numCandidates)
 	}
-	fillTable(test.table, nodes.entries)
+	fillTable(test.table, nodes.entries, false)
 
 	// ensure there's a bond with the test node,
 	// findnode won't be accepted otherwise.

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newMeteredTable(t, t.db, cfg.Bootnodes, cfg.Log, cfg.FilterFunction)
+	tab, err := newMeteredTable(t, t.db, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +652,7 @@ func (t *UDPv5) handlePacket(rawpacket []byte, fromAddr *net.UDPAddr) error {
 	}
 	if fromNode != nil {
 		// Handshake succeeded, add to table.
-		t.tab.addSeenNode(wrapNode(fromNode))
+		t.tab.addInboundNode(wrapNode(fromNode))
 	}
 	if packet.Kind() != v5wire.WhoareyouPacket {
 		// WHOAREYOU logged separately to report errors.

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -145,7 +145,7 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 
 	// Make node known.
 	n := test.getNode(test.remotekey, test.remoteaddr).Node()
-	test.table.addSeenNodeSync(wrapNode(n))
+	test.table.addFoundNode(wrapNode(n))
 
 	test.packetIn(&v5wire.Unknown{Nonce: nonce})
 	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {
@@ -163,9 +163,9 @@ func TestUDPv5_findnodeHandling(t *testing.T) {
 	nodes253 := nodesAtDistance(test.table.self().ID(), 253, 10)
 	nodes249 := nodesAtDistance(test.table.self().ID(), 249, 4)
 	nodes248 := nodesAtDistance(test.table.self().ID(), 248, 10)
-	fillTable(test.table, wrapNodes(nodes253))
-	fillTable(test.table, wrapNodes(nodes249))
-	fillTable(test.table, wrapNodes(nodes248))
+	fillTable(test.table, wrapNodes(nodes253), true)
+	fillTable(test.table, wrapNodes(nodes249), true)
+	fillTable(test.table, wrapNodes(nodes248), true)
 
 	// Requesting with distance zero should return the node's own record.
 	test.packetIn(&v5wire.Findnode{ReqID: []byte{0}, Distances: []uint{0}})
@@ -539,7 +539,7 @@ func TestUDPv5_lookup(t *testing.T) {
 
 	// Seed table with initial node.
 	initialNode := lookupTestnet.node(256, 0)
-	fillTable(test.table, []*node{wrapNode(initialNode)})
+	fillTable(test.table, []*node{wrapNode(initialNode)}, true)
 
 	// Start the lookup.
 	resultC := make(chan []*enode.Node, 1)


### PR DESCRIPTION
## Description
Cherry-picked following commits from go-ethereum to improve table revalidation and fix some follow-after issues.

https://github.com/ethereum/go-ethereum/pull/29572
https://github.com/ethereum/go-ethereum/pull/29864
https://github.com/ethereum/go-ethereum/pull/29836
https://github.com/ethereum/go-ethereum/pull/30239

## Problem
The current node discovery revalidation process in the distributed network has issues leading to inconsistent results, such as unexpected node drops (drop at the first time that revalidate failed) and uneven revalidation frequencies. The old approach involved selecting a random bucket every ~10s, validating the last node via PING, and replacing it if unresponsive. However, it was inefficient, revalidating each node every ~13.3 minutes, with uneven distribution favoring less-populated buckets.

## Benchmark result
**Strategy**: Use p2psim to simulate a network of 200 nodes which includes 50% unhealthy nodes.

![image](https://github.com/user-attachments/assets/c1968f6f-ced6-4e49-a9f4-f5755aa1c789)

**Conclustion**:

- New strategy has a better distribution based on nodes in DHT than the older
- The distribution of tries to revalidate directly affects the efficiency of how a node removes unhealthy nodes in its DHT → Demonstrate by above RemovedRevalidation charts, new strategy removes unhealthy nodes faster than the older