### PR TITLE
p2p: add a flag to only accept connection from a trusted peer

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -153,6 +153,7 @@ var (
 		utils.NodeKeyFileFlag,
 		utils.NodeKeyHexFlag,
 		utils.DNSDiscoveryFlag,
+		utils.TrustedNodesOnlyFlag,
 		utils.MainnetFlag,
 		utils.DeveloperFlag,
 		utils.DeveloperPeriodFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -880,6 +880,11 @@ var (
 		Usage:    "Sets DNS discovery entry points (use \"\" to disable DNS)",
 		Category: flags.NetworkingCategory,
 	}
+	TrustedNodesOnlyFlag = &cli.BoolFlag{
+		Name:     "trusted-node-only",
+		Usage:    "Only accept p2p connection from a trusted node",
+		Category: flags.NetworkingCategory,
+	}
 
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = &flags.DirectoryFlag{
@@ -1551,6 +1556,8 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 		cfg.NoDiscovery = true
 		cfg.DiscoveryV5 = false
 	}
+
+	cfg.TrustedNodesOnly = ctx.Bool(TrustedNodesOnlyFlag.Name)
 }
 
 // SetNodeConfig applies node-related command line flags to the config.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -168,6 +168,9 @@ type Config struct {
 	Logger log.Logger `toml:",omitempty"`
 
 	clock mclock.Clock
+
+	// Only accept connection from a trusted node.
+	TrustedNodesOnly bool
 }
 
 // Server manages all peer connections.
@@ -870,6 +873,8 @@ running:
 
 func (srv *Server) postHandshakeChecks(peers map[enode.ID]*Peer, inboundCount int, c *conn) error {
 	switch {
+	case !c.is(trustedConn) && srv.Config.TrustedNodesOnly:
+		return DiscUselessPeer
 	case !c.is(trustedConn) && len(peers) >= srv.MaxPeers:
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():


### PR DESCRIPTION
This commit adds flag --trusted-node-only, when using this flag, node will only accept connection from a trusted peer. This is suboptimal as it does not change the dial logic which still tries to dial not trusted peer. But it works for now, the dial part can be in the future improvement.