### PR TITLE
all: adapt blockchain test

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -602,7 +602,10 @@ func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.H
 func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs *[]*types.Transaction,
 	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, internalTxs *[]*types.InternalTransaction, usedGas *uint64) error {
 	// Accumulate any block and uncle rewards and commit the final state root
-	accumulateRewards(chain.Config(), state, header, uncles)
+	// Note: After Paris hardfork, the block reward is set to 0
+	if !chain.Config().IsShanghai(header.Number) {
+		accumulateRewards(chain.Config(), state, header, uncles)
+	}
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	return nil
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -62,10 +62,12 @@ type Genesis struct {
 
 	// These fields are used for consensus tests. Please don't use them
 	// in actual genesis blocks.
-	Number     uint64      `json:"number"`
-	GasUsed    uint64      `json:"gasUsed"`
-	ParentHash common.Hash `json:"parentHash"`
-	BaseFee    *big.Int    `json:"baseFeePerGas"`
+	Number        uint64      `json:"number"`
+	GasUsed       uint64      `json:"gasUsed"`
+	ParentHash    common.Hash `json:"parentHash"`
+	BaseFee       *big.Int    `json:"baseFeePerGas"`
+	ExcessBlobGas *uint64     `json:"excessBlobGas"` // EIP-4844
+	BlobGasUsed   *uint64     `json:"blobGasUsed"`   // EIP-4844
 }
 
 // hashAlloc computes the state root according to the genesis specification.
@@ -299,18 +301,20 @@ func (g *Genesis) ToBlock() *types.Block {
 		panic(err)
 	}
 	head := &types.Header{
-		Number:     new(big.Int).SetUint64(g.Number),
-		Nonce:      types.EncodeNonce(g.Nonce),
-		Time:       g.Timestamp,
-		ParentHash: g.ParentHash,
-		Extra:      g.ExtraData,
-		GasLimit:   g.GasLimit,
-		GasUsed:    g.GasUsed,
-		BaseFee:    g.BaseFee,
-		Difficulty: g.Difficulty,
-		MixDigest:  g.Mixhash,
-		Coinbase:   g.Coinbase,
-		Root:       root,
+		Number:        new(big.Int).SetUint64(g.Number),
+		Nonce:         types.EncodeNonce(g.Nonce),
+		Time:          g.Timestamp,
+		ParentHash:    g.ParentHash,
+		Extra:         g.ExtraData,
+		GasLimit:      g.GasLimit,
+		GasUsed:       g.GasUsed,
+		BaseFee:       g.BaseFee,
+		Difficulty:    g.Difficulty,
+		MixDigest:     g.Mixhash,
+		Coinbase:      g.Coinbase,
+		Root:          root,
+		BlobGasUsed:   g.BlobGasUsed,
+		ExcessBlobGas: g.ExcessBlobGas,
 	}
 	if g.GasLimit == 0 {
 		head.GasLimit = params.GenesisGasLimit

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -75,8 +75,10 @@ func TestExecutionSpecBlocktests(t *testing.T) {
 		t.Skipf("directory %s does not exist", executionSpecBlockchainTestDir)
 	}
 	bt := new(testMatcher)
-	// TODO: adapt blockchain tests to execution spec tests, skip tests for now
-	bt.skipLoad(`.*/`)
+
+	// Skip not supported transition fork tests
+	bt.skipLoad(`^cancun/eip7516_blobgasfee/blobgasfee_opcode/blobbasefee_before_fork.json`)
+
 	bt.walk(t, executionSpecBlockchainTestDir, func(t *testing.T, name string, test *BlockTest) {
 		execBlockTest(t, bt, test)
 	})

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -320,6 +320,12 @@ func (t *BlockTest) validatePostState(statedb *state.StateDB) error {
 		if nonce2 != acct.Nonce {
 			return fmt.Errorf("account nonce mismatch for addr: %s want: %d have: %d", addr, acct.Nonce, nonce2)
 		}
+		for k, v := range acct.Storage {
+			v2 := statedb.GetState(addr, k)
+			if v2 != v {
+				return fmt.Errorf("account storage mismatch for addr: %s, slot: %x, want: %x, have: %x", addr, k, v, v2)
+			}
+		}
 	}
 	return nil
 }

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -89,6 +90,8 @@ type btHeader struct {
 	GasUsed          uint64
 	Timestamp        uint64
 	BaseFeePerGas    *big.Int
+	BlobGasUsed      *uint64
+	ExcessBlobGas    *uint64
 }
 
 type btHeaderMarshaling struct {
@@ -99,6 +102,8 @@ type btHeaderMarshaling struct {
 	GasUsed       math.HexOrDecimal64
 	Timestamp     math.HexOrDecimal64
 	BaseFeePerGas *math.HexOrDecimal256
+	BlobGasUsed   *math.HexOrDecimal64
+	ExcessBlobGas *math.HexOrDecimal64
 }
 
 func (t *BlockTest) Run(snapshotter bool, scheme string) error {
@@ -119,7 +124,8 @@ func (t *BlockTest) Run(snapshotter bool, scheme string) error {
 	}
 	triedb := trie.NewDatabase(db, tconf)
 	// Commit genesis state
-	gblock := t.genesis(config).MustCommit(db, triedb)
+	gspec := t.genesis(config)
+	gblock := gspec.MustCommit(db, triedb)
 	triedb.Close()
 	if gblock.Hash() != t.json.Genesis.Hash {
 		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", gblock.Hash().Bytes()[:6], t.json.Genesis.Hash[:6])
@@ -137,9 +143,6 @@ func (t *BlockTest) Run(snapshotter bool, scheme string) error {
 	if snapshotter {
 		cache.SnapshotLimit = 1
 		cache.SnapshotWait = true
-	}
-	gspec := &core.Genesis{
-		Config: config,
 	}
 	chain, err := core.NewBlockChain(db, cache, gspec, nil, engine, vm.Config{}, nil, nil)
 	if err != nil {
@@ -173,18 +176,20 @@ func (t *BlockTest) Run(snapshotter bool, scheme string) error {
 
 func (t *BlockTest) genesis(config *params.ChainConfig) *core.Genesis {
 	return &core.Genesis{
-		Config:     config,
-		Nonce:      t.json.Genesis.Nonce.Uint64(),
-		Timestamp:  t.json.Genesis.Timestamp,
-		ParentHash: t.json.Genesis.ParentHash,
-		ExtraData:  t.json.Genesis.ExtraData,
-		GasLimit:   t.json.Genesis.GasLimit,
-		GasUsed:    t.json.Genesis.GasUsed,
-		Difficulty: t.json.Genesis.Difficulty,
-		Mixhash:    t.json.Genesis.MixHash,
-		Coinbase:   t.json.Genesis.Coinbase,
-		Alloc:      t.json.Pre,
-		BaseFee:    t.json.Genesis.BaseFeePerGas,
+		Config:        config,
+		Nonce:         t.json.Genesis.Nonce.Uint64(),
+		Timestamp:     t.json.Genesis.Timestamp,
+		ParentHash:    t.json.Genesis.ParentHash,
+		ExtraData:     t.json.Genesis.ExtraData,
+		GasLimit:      t.json.Genesis.GasLimit,
+		GasUsed:       t.json.Genesis.GasUsed,
+		Difficulty:    t.json.Genesis.Difficulty,
+		Mixhash:       t.json.Genesis.MixHash,
+		Coinbase:      t.json.Genesis.Coinbase,
+		Alloc:         t.json.Pre,
+		BaseFee:       t.json.Genesis.BaseFeePerGas,
+		BlobGasUsed:   t.json.Genesis.BlobGasUsed,
+		ExcessBlobGas: t.json.Genesis.ExcessBlobGas,
 	}
 }
 
@@ -286,6 +291,15 @@ func validateHeader(h *btHeader, h2 *types.Header) error {
 	}
 	if h.Timestamp != h2.Time {
 		return fmt.Errorf("timestamp: want: %v have: %v", h.Timestamp, h2.Time)
+	}
+	if !reflect.DeepEqual(h.BaseFeePerGas, h2.BaseFee) {
+		return fmt.Errorf("baseFeePerGas: want: %v have: %v", h.BaseFeePerGas, h2.BaseFee)
+	}
+	if !reflect.DeepEqual(h.BlobGasUsed, h2.BlobGasUsed) {
+		return fmt.Errorf("blobGasUsed: want: %v have: %v", h.BlobGasUsed, h2.BlobGasUsed)
+	}
+	if !reflect.DeepEqual(h.ExcessBlobGas, h2.ExcessBlobGas) {
+		return fmt.Errorf("excessBlobGas: want: %v have: %v", h.ExcessBlobGas, h2.ExcessBlobGas)
 	}
 	return nil
 }

--- a/tests/download-fixtures.sh
+++ b/tests/download-fixtures.sh
@@ -3,5 +3,5 @@ cd ..
 git submodule update --init --depth 1 --recursive
 cd tests
 rm -rf spec-tests && mkdir spec-tests && cd spec-tests
-wget https://github.com/ronin-chain/execution-spec-tests/releases/download/v1.0.1/fixtures_stable.tar.gz
+wget https://github.com/ronin-chain/execution-spec-tests/releases/download/v1.0.2/fixtures_stable.tar.gz
 tar xzf fixtures_stable.tar.gz && rm -f fixtures_stable.tar.gz

--- a/tests/gen_btheader.go
+++ b/tests/gen_btheader.go
@@ -34,6 +34,8 @@ func (b btHeader) MarshalJSON() ([]byte, error) {
 		GasUsed          math.HexOrDecimal64
 		Timestamp        math.HexOrDecimal64
 		BaseFeePerGas    *math.HexOrDecimal256
+		BlobGasUsed      *math.HexOrDecimal64
+		ExcessBlobGas    *math.HexOrDecimal64
 	}
 	var enc btHeader
 	enc.Bloom = b.Bloom
@@ -53,6 +55,8 @@ func (b btHeader) MarshalJSON() ([]byte, error) {
 	enc.GasUsed = math.HexOrDecimal64(b.GasUsed)
 	enc.Timestamp = math.HexOrDecimal64(b.Timestamp)
 	enc.BaseFeePerGas = (*math.HexOrDecimal256)(b.BaseFeePerGas)
+	enc.BlobGasUsed = (*math.HexOrDecimal64)(b.BlobGasUsed)
+	enc.ExcessBlobGas = (*math.HexOrDecimal64)(b.ExcessBlobGas)
 	return json.Marshal(&enc)
 }
 
@@ -76,6 +80,8 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 		GasUsed          *math.HexOrDecimal64
 		Timestamp        *math.HexOrDecimal64
 		BaseFeePerGas    *math.HexOrDecimal256
+		BlobGasUsed      *math.HexOrDecimal64
+		ExcessBlobGas    *math.HexOrDecimal64
 	}
 	var dec btHeader
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -131,6 +137,12 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 	}
 	if dec.BaseFeePerGas != nil {
 		b.BaseFeePerGas = (*big.Int)(dec.BaseFeePerGas)
+	}
+	if dec.BlobGasUsed != nil {
+		b.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
+	}
+	if dec.ExcessBlobGas != nil {
+		b.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
 	}
 	return nil
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -181,6 +181,7 @@ var Forks = map[string]*params.ChainConfig{
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
+		VenokiBlock:         big.NewInt(0),
 	},
 	"ArrowGlacier": {
 		ChainID:             big.NewInt(1),
@@ -212,6 +213,7 @@ var Forks = map[string]*params.ChainConfig{
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 		ShanghaiBlock:       big.NewInt(0),
+		VenokiBlock:         big.NewInt(0),
 	},
 	"Cancun": {
 		ChainID:                 big.NewInt(1),
@@ -230,6 +232,7 @@ var Forks = map[string]*params.ChainConfig{
 		ShanghaiBlock:           big.NewInt(0),
 		CancunBlock:             big.NewInt(0),
 		TerminalTotalDifficulty: big.NewInt(0),
+		VenokiBlock:             big.NewInt(0),
 	},
 }
 


### PR DESCRIPTION
## Description

This PR introduces:
- Add `BlobGasUsed` and `ExcessBlobGas` to genesis and header of block in `block_test` to ensure block hash matches with generated spec-tests.
- After Paris hardfork, the block reward is set to 0 because the transition from PoW to PoS ([EIP-3675](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3675.md)). Since Ronin does not declare the `Paris` hardfork and uses a different consensus mechanism than geth, this PR uses the `Shanghai` hardfork instead to specify the consensus rule that sets the reward to 0.

## Result

```
$ go test -tags=blst_enabled,ckzg -timeout 30m -v -count=1 github.com/ethereum/go-ethereum/tests -run "TestState|TestExecutionSpecState|TestTransaction|TestRLP"
PASS
ok      github.com/ethereum/go-ethereum/tests   2.395s
```