### PR TITLE
core, eth/tracers: move chainconfig to tracers and some refactors

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -650,6 +650,7 @@ var (
 	VMTraceConfigFlag = &cli.StringFlag{
 		Name:     "vmtrace.config",
 		Usage:    "Tracer configuration (JSON)",
+		Value:    "{}",
 		Category: flags.VMCategory,
 	}
 	RPCGlobalGasCapFlag = &cli.Uint64Flag{
@@ -2147,13 +2148,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// VM tracing config.
 	if ctx.IsSet(VMTraceFlag.Name) {
 		if name := ctx.String(VMTraceFlag.Name); name != "" {
-			var config string
-			if ctx.IsSet(VMTraceConfigFlag.Name) {
-				config = ctx.String(VMTraceConfigFlag.Name)
-			}
-
 			cfg.VMTrace = name
-			cfg.VMTraceConfig = config
+			cfg.VMTraceConfig = ctx.String(VMTraceConfigFlag.Name)
 		}
 	}
 	if ctx.IsSet(DisableTxBroadcastFromFlag.Name) {
@@ -2428,10 +2424,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.Bool(VMEnableDebugFlag.Name)}
 	if ctx.IsSet(VMTraceFlag.Name) {
 		if name := ctx.String(VMTraceFlag.Name); name != "" {
-			var config json.RawMessage
-			if ctx.IsSet(VMTraceConfigFlag.Name) {
-				config = json.RawMessage(ctx.String(VMTraceConfigFlag.Name))
-			}
+			config := json.RawMessage(ctx.String(VMTraceConfigFlag.Name))
 			t, err := tracers.LiveDirectory.New(name, config)
 			if err != nil {
 				Fatalf("Failed to create tracer %q: %v", name, err)

--- a/core/tracing/hooks.go
+++ b/core/tracing/hooks.go
@@ -62,9 +62,8 @@ type VMContext struct {
 	BlockNumber *big.Int
 	Time        uint64
 	// Effective tx gas price
-	GasPrice    *big.Int
-	ChainConfig *params.ChainConfig
-	StateDB     StateDB
+	GasPrice *big.Int
+	StateDB  StateDB
 }
 
 // BlockEvent is emitted upon tracing an incoming block.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -695,7 +695,6 @@ func (evm *EVM) GetVMContext() *tracing.VMContext {
 		BlockNumber: evm.Context.BlockNumber,
 		Time:        evm.Context.Time,
 		GasPrice:    evm.TxContext.GasPrice,
-		ChainConfig: evm.ChainConfig(),
 		StateDB:     evm.StateDB,
 	}
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -330,7 +330,7 @@ func benchmarkNonModifyingCode(gas uint64, code []byte, name string, tracerCode 
 	cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	cfg.GasLimit = gas
 	if len(tracerCode) > 0 {
-		tracer, err := tracers.DefaultDirectory.New(tracerCode, new(tracers.Context), nil)
+		tracer, err := tracers.DefaultDirectory.New(tracerCode, new(tracers.Context), nil, cfg.ChainConfig)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -826,7 +826,7 @@ func TestRuntimeJSTracer(t *testing.T) {
 			statedb.SetCode(common.HexToAddress("0xee"), calleeCode)
 			statedb.SetCode(common.HexToAddress("0xff"), depressedCode)
 
-			tracer, err := tracers.DefaultDirectory.New(jsTracer, new(tracers.Context), nil)
+			tracer, err := tracers.DefaultDirectory.New(jsTracer, new(tracers.Context), nil, params.MainnetChainConfig)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -861,7 +861,7 @@ func TestJSTracerCreateTx(t *testing.T) {
 	code := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.RETURN)}
 
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	tracer, err := tracers.DefaultDirectory.New(jsTracer, new(tracers.Context), nil)
+	tracer, err := tracers.DefaultDirectory.New(jsTracer, new(tracers.Context), nil, params.MainnetChainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1130,7 +1130,7 @@ func (api *API) traceTx(
 			Stop:      logger.Stop,
 		}
 	} else {
-		tracer, err = DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig)
+		tracer, err = DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig, api.backend.ChainConfig())
 		if err != nil {
 			return nil, err
 		}

--- a/eth/tracers/dir.go
+++ b/eth/tracers/dir.go
@@ -80,6 +80,9 @@ func (d *directory) RegisterJSEval(f jsCtorFn) {
 // registered lookups. Name is either name of an existing tracer
 // or an arbitrary JS code.
 func (d *directory) New(name string, ctx *Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*Tracer, error) {
+	if len(cfg) == 0 {
+		cfg = json.RawMessage("{}")
+	}
 	if elem, ok := d.elems[name]; ok {
 		return elem.ctor(ctx, cfg, chainConfig)
 	}

--- a/eth/tracers/dir.go
+++ b/eth/tracers/dir.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // Context contains some contextual infos for a transaction execution that is not
@@ -44,8 +45,8 @@ type Tracer struct {
 	Stop func(err error)
 }
 
-type ctorFn func(*Context, json.RawMessage) (*Tracer, error)
-type jsCtorFn func(string, *Context, json.RawMessage) (*Tracer, error)
+type ctorFn func(*Context, json.RawMessage, *params.ChainConfig) (*Tracer, error)
+type jsCtorFn func(string, *Context, json.RawMessage, *params.ChainConfig) (*Tracer, error)
 
 type elem struct {
 	ctor ctorFn
@@ -78,12 +79,12 @@ func (d *directory) RegisterJSEval(f jsCtorFn) {
 // New returns a new instance of a tracer, by iterating through the
 // registered lookups. Name is either name of an existing tracer
 // or an arbitrary JS code.
-func (d *directory) New(name string, ctx *Context, cfg json.RawMessage) (*Tracer, error) {
+func (d *directory) New(name string, ctx *Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*Tracer, error) {
 	if elem, ok := d.elems[name]; ok {
-		return elem.ctor(ctx, cfg)
+		return elem.ctor(ctx, cfg, chainConfig)
 	}
 	// Assume JS code
-	return d.jsEval(name, ctx, cfg)
+	return d.jsEval(name, ctx, cfg, chainConfig)
 }
 
 // IsJS will return true if the given tracer will evaluate

--- a/eth/tracers/internal/tracetest/calltrace2_test.go
+++ b/eth/tracers/internal/tracetest/calltrace2_test.go
@@ -166,7 +166,7 @@ func testCallTracer2(tracerName string, dirPath string, scheme string, t *testin
 				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			defer triedb.Close()
-			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)
+			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig, test.Genesis.Config)
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
@@ -276,7 +276,7 @@ func benchTracer2(tracerName string, test *callTracer2Test, b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)
+		tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig, test.Genesis.Config)
 		if err != nil {
 			b.Fatalf("failed to create call tracer: %v", err)
 		}
@@ -343,8 +343,9 @@ func TestZeroValueToNotExitCall2(t *testing.T) {
 	}
 	triedb, _, statedb := tests.MakePreState(rawdb.NewMemoryDatabase(), alloc, false, rawdb.HashScheme)
 	defer triedb.Close()
+	chainConfig := params.MainnetChainConfig
 	// Create the tracer, the EVM environment and run it
-	tracer, err := tracers.DefaultDirectory.New("callTracer2", new(tracers.Context), nil)
+	tracer, err := tracers.DefaultDirectory.New("callTracer2", new(tracers.Context), nil, chainConfig)
 	if err != nil {
 		t.Fatalf("failed to create call tracer: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestZeroValueToNotExitCall2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	evm := vm.NewEVM(context, txContext, statedb, params.MainnetChainConfig, vm.Config{Debug: true, Tracer: tracer.Hooks})
+	evm := vm.NewEVM(context, txContext, statedb, chainConfig, vm.Config{Debug: true, Tracer: tracer.Hooks})
 	statedb.SetLogger(tracer.Hooks)
 	tracer.OnTxStart(evm.GetVMContext(), tx, msg.Payer)
 	vmRet, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(tx.Gas()))

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -146,7 +146,7 @@ func testCallTracer(tracerName string, dirPath string, scheme string, t *testing
 				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			triedb.Close()
-			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)
+			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig, test.Genesis.Config)
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}
@@ -253,7 +253,7 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), nil)
+		tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), nil, test.Genesis.Config)
 		if err != nil {
 			b.Fatalf("failed to create call tracer: %v", err)
 		}
@@ -290,7 +290,7 @@ func TestInternals(t *testing.T) {
 		}
 	)
 	mkTracer := func(name string, cfg json.RawMessage) *tracers.Tracer {
-		tr, err := tracers.DefaultDirectory.New(name, nil, cfg)
+		tr, err := tracers.DefaultDirectory.New(name, nil, cfg, config)
 		if err != nil {
 			t.Fatalf("failed to create call tracer: %v", err)
 		}

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -104,7 +104,7 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 	defer triedb.Close()
 
 	// Create the tracer, the EVM environment and run it
-	tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)
+	tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig, test.Genesis.Config)
 	if err != nil {
 		return fmt.Errorf("failed to create call tracer: %v", err)
 	}

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -114,7 +114,7 @@ func testPrestateDiffTracer(tracerName string, dirPath string, scheme string, t 
 				triedb, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, scheme)
 			)
 			defer triedb.Close()
-			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig)
+			tracer, err := tracers.DefaultDirectory.New(tracerName, new(tracers.Context), test.TracerConfig, test.Genesis.Config)
 			if err != nil {
 				t.Fatalf("failed to create call tracer: %v", err)
 			}

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/eth/tracers/internal"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -45,10 +46,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	type ctorFn = func(*tracers.Context, json.RawMessage) (*tracers.Tracer, error)
+	type ctorFn = func(*tracers.Context, json.RawMessage, *params.ChainConfig) (*tracers.Tracer, error)
 	lookup := func(code string) ctorFn {
-		return func(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
-			return newJsTracer(code, ctx, cfg)
+		return func(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
+			return newJsTracer(code, ctx, cfg, chainConfig)
 		}
 	}
 	for name, code := range assetTracers {
@@ -101,6 +102,7 @@ func fromBuf(vm *goja.Runtime, bufType goja.Value, buf goja.Value, allowString b
 type jsTracer struct {
 	vm                *goja.Runtime
 	env               *tracing.VMContext
+	chainConfig       *params.ChainConfig
 	toBig             toBigFn               // Converts a hex string into a JS bigint
 	toBuf             toBufFn               // Converts a []byte into a JS buffer
 	fromBuf           fromBufFn             // Converts an array, hex string or Uint8Array to a []byte
@@ -137,13 +139,14 @@ type jsTracer struct {
 // The methods `result` and `fault` are required to be present.
 // The methods `step`, `enter`, and `exit` are optional, but note that
 // `enter` and `exit` always go together.
-func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	vm := goja.New()
 	// By default field names are exported to JS as is, i.e. capitalized.
 	vm.SetFieldNameMapper(goja.UncapFieldNameMapper())
 	t := &jsTracer{
-		vm:  vm,
-		ctx: make(map[string]goja.Value),
+		vm:          vm,
+		ctx:         make(map[string]goja.Value),
+		chainConfig: chainConfig,
 	}
 
 	t.setTypeConverters()
@@ -243,7 +246,7 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from
 	db := &dbObj{db: env.StateDB, vm: t.vm, toBig: t.toBig, toBuf: t.toBuf, fromBuf: t.fromBuf}
 	t.dbValue = db.setupObject()
 	// Update list of precompiles based on current block
-	rules := env.ChainConfig.Rules(env.BlockNumber)
+	rules := t.chainConfig.Rules(env.BlockNumber)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 	t.ctx["block"] = t.vm.ToValue(t.env.BlockNumber.Uint64())
 	t.ctx["gas"] = t.vm.ToValue(tx.Gas())

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -90,11 +90,12 @@ func runTrace(tracer *tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCo
 func TestTracer(t *testing.T) {
 	execTracer := func(code string, contract []byte) ([]byte, string) {
 		t.Helper()
-		tracer, err := newJsTracer(code, nil, nil)
+		chainConfig := params.TestChainConfig
+		tracer, err := newJsTracer(code, nil, nil, chainConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
-		ret, err := runTrace(tracer, testCtx(), params.TestChainConfig, contract)
+		ret, err := runTrace(tracer, testCtx(), chainConfig, contract)
 		if err != nil {
 			return nil, err.Error() // Stringify to allow comparison without nil checks
 		}
@@ -164,7 +165,8 @@ func TestTracer(t *testing.T) {
 
 func TestHalt(t *testing.T) {
 	timeout := errors.New("stahp")
-	tracer, err := newJsTracer("{step: function() { while(1); }, result: function() { return null; }, fault: function(){}}", nil, nil)
+	chainConfig := params.TestChainConfig
+	tracer, err := newJsTracer("{step: function() { while(1); }, result: function() { return null; }, fault: function(){}}", nil, nil, chainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +180,8 @@ func TestHalt(t *testing.T) {
 }
 
 func TestHaltBetweenSteps(t *testing.T) {
-	tracer, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }}", nil, nil)
+	chainConfig := params.TestChainConfig
+	tracer, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }}", nil, nil, chainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,11 +206,12 @@ func TestHaltBetweenSteps(t *testing.T) {
 func TestNoStepExec(t *testing.T) {
 	execTracer := func(code string) []byte {
 		t.Helper()
-		tracer, err := newJsTracer(code, nil, nil)
+		chainConfig := params.TestChainConfig
+		tracer, err := newJsTracer(code, nil, nil, chainConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
-		env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{GasPrice: big.NewInt(100)}, &dummyStatedb{}, params.TestChainConfig, vm.Config{Tracer: tracer.Hooks})
+		env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{GasPrice: big.NewInt(100)}, &dummyStatedb{}, chainConfig, vm.Config{Tracer: tracer.Hooks})
 		tracer.OnTxStart(env.GetVMContext(), types.NewTx(&types.LegacyTx{}), common.Address{})
 		tracer.OnEnter(0, byte(vm.CALL), common.Address{}, common.Address{}, []byte{}, 1000, big.NewInt(0), 0)
 		tracer.OnExit(0, nil, 0, nil, false)
@@ -238,7 +242,7 @@ func TestIsPrecompile(t *testing.T) {
 	chaincfg.IstanbulBlock = big.NewInt(200)
 	chaincfg.BerlinBlock = big.NewInt(300)
 	txCtx := vm.TxContext{GasPrice: big.NewInt(100000)}
-	tracer, err := newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil, nil)
+	tracer, err := newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil, nil, chaincfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +256,7 @@ func TestIsPrecompile(t *testing.T) {
 		t.Errorf("tracer should not consider blake2f as precompile in byzantium")
 	}
 
-	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil, nil)
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil, nil, chaincfg)
 	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(250)}
 	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg, nil)
 	if err != nil {
@@ -264,15 +268,16 @@ func TestIsPrecompile(t *testing.T) {
 }
 
 func TestEnterExit(t *testing.T) {
+	chainConfig := params.TestChainConfig
 	// test that either both or none of enter() and exit() are defined
-	if _, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }, enter: function() {}}", new(tracers.Context), nil); err == nil {
+	if _, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }, enter: function() {}}", new(tracers.Context), nil, chainConfig); err == nil {
 		t.Fatal("tracer creation should've failed without exit() definition")
 	}
-	if _, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }, enter: function() {}, exit: function() {}}", new(tracers.Context), nil); err != nil {
+	if _, err := newJsTracer("{step: function() {}, fault: function() {}, result: function() { return null; }, enter: function() {}, exit: function() {}}", new(tracers.Context), nil, chainConfig); err != nil {
 		t.Fatal(err)
 	}
 	// test that the enter and exit method are correctly invoked and the values passed
-	tracer, err := newJsTracer("{enters: 0, exits: 0, enterGas: 0, gasUsed: 0, step: function() {}, fault: function() {}, result: function() { return {enters: this.enters, exits: this.exits, enterGas: this.enterGas, gasUsed: this.gasUsed} }, enter: function(frame) { this.enters++; this.enterGas = frame.getGas(); }, exit: function(res) { this.exits++; this.gasUsed = res.getGasUsed(); }}", new(tracers.Context), nil)
+	tracer, err := newJsTracer("{enters: 0, exits: 0, enterGas: 0, gasUsed: 0, step: function() {}, fault: function() {}, result: function() { return {enters: this.enters, exits: this.exits, enterGas: this.enterGas, gasUsed: this.gasUsed} }, enter: function(frame) { this.enters++; this.enterGas = frame.getGas(); }, exit: function(res) { this.exits++; this.gasUsed = res.getGasUsed(); }}", new(tracers.Context), nil, chainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,8 +298,9 @@ func TestEnterExit(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
+	chainConfig := params.TestChainConfig
 	// Test empty config
-	_, err := newJsTracer(`{setup: function(cfg) { if (cfg !== "{}") { throw("invalid empty config") } }, fault: function() {}, result: function() {}}`, new(tracers.Context), nil)
+	_, err := newJsTracer(`{setup: function(cfg) { if (cfg !== "{}") { throw("invalid empty config") } }, fault: function() {}, result: function() {}}`, new(tracers.Context), nil, chainConfig)
 	if err != nil {
 		t.Error(err)
 	}
@@ -304,12 +310,12 @@ func TestSetup(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test no setup func
-	_, err = newJsTracer(`{fault: function() {}, result: function() {}}`, new(tracers.Context), cfg)
+	_, err = newJsTracer(`{fault: function() {}, result: function() {}}`, new(tracers.Context), cfg, chainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Test config value
-	tracer, err := newJsTracer("{config: null, setup: function(cfg) { this.config = JSON.parse(cfg) }, step: function() {}, fault: function() {}, result: function() { return this.config.foo }}", new(tracers.Context), cfg)
+	tracer, err := newJsTracer("{config: null, setup: function(cfg) { this.config = JSON.parse(cfg) }, step: function() {}, fault: function() {}, result: function() { return this.config.foo }}", new(tracers.Context), cfg, chainConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/tracers/live.go
+++ b/eth/tracers/live.go
@@ -24,6 +24,9 @@ func (d *liveDirectory) Register(name string, f ctorFunc) {
 
 // New instantiates a tracer by name.
 func (d *liveDirectory) New(name string, config json.RawMessage) (*tracing.Hooks, error) {
+	if len(config) == 0 {
+		config = json.RawMessage("{}")
+	}
 	if f, ok := d.elems[name]; ok {
 		return f(config)
 	}

--- a/eth/tracers/live/noop.go
+++ b/eth/tracers/live/noop.go
@@ -1,0 +1,96 @@
+package live
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func init() {
+	tracers.LiveDirectory.Register("noop", newNoopTracer)
+}
+
+// noop is a no-op live tracer. It's there to
+// catch changes in the tracing interface, as well as
+// for testing live tracing performance. Can be removed
+// as soon as we have a real live tracer.
+type noop struct{}
+
+func newNoopTracer(_ json.RawMessage) (*tracing.Hooks, error) {
+	t := &noop{}
+	return &tracing.Hooks{
+		OnTxStart:        t.OnTxStart,
+		OnTxEnd:          t.OnTxEnd,
+		OnEnter:          t.OnEnter,
+		OnExit:           t.OnExit,
+		OnOpcode:         t.OnOpcode,
+		OnFault:          t.OnFault,
+		OnGasChange:      t.OnGasChange,
+		OnBlockchainInit: t.OnBlockchainInit,
+		OnBlockStart:     t.OnBlockStart,
+		OnBlockEnd:       t.OnBlockEnd,
+		OnSkippedBlock:   t.OnSkippedBlock,
+		OnGenesisBlock:   t.OnGenesisBlock,
+		OnBalanceChange:  t.OnBalanceChange,
+		OnNonceChange:    t.OnNonceChange,
+		OnCodeChange:     t.OnCodeChange,
+		OnStorageChange:  t.OnStorageChange,
+		OnLog:            t.OnLog,
+	}, nil
+}
+
+func (t *noop) OnOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+}
+
+func (t *noop) OnFault(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, depth int, err error) {
+}
+
+func (t *noop) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int, order uint64) {
+}
+
+func (t *noop) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+}
+
+func (t *noop) OnTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+}
+
+func (t *noop) OnTxEnd(receipt *types.Receipt, err error) {
+}
+
+func (t *noop) OnBlockStart(ev tracing.BlockEvent) {
+}
+
+func (t *noop) OnBlockEnd(err error) {
+}
+
+func (t *noop) OnSkippedBlock(ev tracing.BlockEvent) {}
+
+func (t *noop) OnBlockchainInit(chainConfig *params.ChainConfig) {
+}
+
+func (t *noop) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+}
+
+func (t *noop) OnBalanceChange(a common.Address, prev, new *big.Int, reason tracing.BalanceChangeReason) {
+}
+
+func (t *noop) OnNonceChange(a common.Address, prev, new uint64) {
+}
+
+func (t *noop) OnCodeChange(a common.Address, prevCodeHash common.Hash, prev []byte, codeHash common.Hash, code []byte) {
+}
+
+func (t *noop) OnStorageChange(a common.Address, k, prev, new common.Hash) {
+}
+
+func (t *noop) OnLog(l *types.Log) {
+
+}
+
+func (t *noop) OnGasChange(old, new uint64, reason tracing.GasChangeReason) {
+}

--- a/eth/tracers/live/supply.go
+++ b/eth/tracers/live/supply.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	tracers.LiveDirectory.Register("supply", newSupply)
+	tracers.LiveDirectory.Register("supply", newSupplyTracer)
 }
 
 type supplyInfoIssuance struct {
@@ -61,7 +61,7 @@ type supplyTxCallstack struct {
 	burn  *big.Int
 }
 
-type supply struct {
+type supplyTracer struct {
 	delta       supplyInfo
 	txCallstack []supplyTxCallstack // Callstack for current transaction
 	logger      *lumberjack.Logger
@@ -72,7 +72,7 @@ type supplyTracerConfig struct {
 	MaxSize int    `json:"maxSize"` // MaxSize is the maximum size in megabytes of the tracer log file before it gets rotated. It defaults to 100 megabytes.
 }
 
-func newSupply(cfg json.RawMessage) (*tracing.Hooks, error) {
+func newSupplyTracer(cfg json.RawMessage) (*tracing.Hooks, error) {
 	var config supplyTracerConfig
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {
@@ -91,19 +91,19 @@ func newSupply(cfg json.RawMessage) (*tracing.Hooks, error) {
 		logger.MaxSize = config.MaxSize
 	}
 
-	t := &supply{
+	t := &supplyTracer{
 		delta:  newSupplyInfo(),
 		logger: logger,
 	}
 	return &tracing.Hooks{
-		OnBlockStart:    t.OnBlockStart,
-		OnBlockEnd:      t.OnBlockEnd,
-		OnGenesisBlock:  t.OnGenesisBlock,
-		OnTxStart:       t.OnTxStart,
-		OnBalanceChange: t.OnBalanceChange,
-		OnEnter:         t.OnEnter,
-		OnExit:          t.OnExit,
-		OnClose:         t.OnClose,
+		OnBlockStart:    t.onBlockStart,
+		OnBlockEnd:      t.onBlockEnd,
+		OnGenesisBlock:  t.onGenesisBlock,
+		OnTxStart:       t.onTxStart,
+		OnBalanceChange: t.onBalanceChange,
+		OnEnter:         t.onEnter,
+		OnExit:          t.onExit,
+		OnClose:         t.onClose,
 	}, nil
 }
 
@@ -125,11 +125,11 @@ func newSupplyInfo() supplyInfo {
 	}
 }
 
-func (s *supply) resetDelta() {
+func (s *supplyTracer) resetDelta() {
 	s.delta = newSupplyInfo()
 }
 
-func (s *supply) OnBlockStart(ev tracing.BlockEvent) {
+func (s *supplyTracer) onBlockStart(ev tracing.BlockEvent) {
 	s.resetDelta()
 
 	s.delta.Number = ev.Block.NumberU64()
@@ -152,11 +152,11 @@ func (s *supply) OnBlockStart(ev tracing.BlockEvent) {
 	}
 }
 
-func (s *supply) OnBlockEnd(err error) {
+func (s *supplyTracer) onBlockEnd(err error) {
 	s.write(s.delta)
 }
 
-func (s *supply) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
+func (s *supplyTracer) onGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
 	s.resetDelta()
 
 	s.delta.Number = b.NumberU64()
@@ -171,10 +171,10 @@ func (s *supply) OnGenesisBlock(b *types.Block, alloc types.GenesisAlloc) {
 	s.write(s.delta)
 }
 
-func (s *supply) OnBalanceChange(a common.Address, prevBalance, newBalance *big.Int, reason tracing.BalanceChangeReason) {
+func (s *supplyTracer) onBalanceChange(a common.Address, prevBalance, newBalance *big.Int, reason tracing.BalanceChangeReason) {
 	diff := new(big.Int).Sub(newBalance, prevBalance)
 
-	// NOTE: don't handle "BalanceIncreaseGenesisBalance" because it is handled in OnGenesisBlock
+	// NOTE: don't handle "BalanceIncreaseGenesisBalance" because it is handled in onGenesisBlock
 	switch reason {
 	case tracing.BalanceIncreaseRewardMineUncle:
 	case tracing.BalanceIncreaseRewardMineBlock:
@@ -188,12 +188,12 @@ func (s *supply) OnBalanceChange(a common.Address, prevBalance, newBalance *big.
 	}
 }
 
-func (s *supply) OnTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+func (s *supplyTracer) onTxStart(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	s.txCallstack = make([]supplyTxCallstack, 0, 1)
 }
 
 // internalTxsHandler handles internal transactions burned amount
-func (s *supply) internalTxsHandler(call *supplyTxCallstack) {
+func (s *supplyTracer) internalTxsHandler(call *supplyTxCallstack) {
 	// Handle Burned amount
 	if call.burn != nil {
 		s.delta.Burn.Misc.Add(s.delta.Burn.Misc, call.burn)
@@ -208,7 +208,7 @@ func (s *supply) internalTxsHandler(call *supplyTxCallstack) {
 	}
 }
 
-func (s *supply) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int, order uint64) {
+func (s *supplyTracer) onEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int, order uint64) {
 	call := supplyTxCallstack{
 		calls: make([]supplyTxCallstack, 0),
 	}
@@ -223,7 +223,7 @@ func (s *supply) OnEnter(depth int, typ byte, from common.Address, to common.Add
 	s.txCallstack = append(s.txCallstack, call)
 }
 
-func (s *supply) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+func (s *supplyTracer) onExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
 	if depth == 0 {
 		// No need to handle Burned amount if transaction is reverted
 		if !reverted {
@@ -249,13 +249,13 @@ func (s *supply) OnExit(depth int, output []byte, gasUsed uint64, err error, rev
 	s.txCallstack[size-1].calls = append(s.txCallstack[size-1].calls, call)
 }
 
-func (s *supply) OnClose() {
+func (s *supplyTracer) onClose() {
 	if err := s.logger.Close(); err != nil {
 		log.Warn("failed to close supply tracer log file", "error", err)
 	}
 }
 
-func (s *supply) write(data any) {
+func (s *supplyTracer) write(data any) {
 	supply, ok := data.(supplyInfo)
 	if !ok {
 		log.Warn("failed to cast supply tracer data on write to log file")

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func init() {
@@ -48,17 +49,19 @@ func init() {
 //	  0xc281d19e-0: 1
 //	}
 type fourByteTracer struct {
-	ids               map[string]int   // ids aggregates the 4byte ids found
-	interrupt         atomic.Bool      // Atomic flag to signal execution interruption
-	reason            error            // Textual reason for the interruption
+	ids               map[string]int // ids aggregates the 4byte ids found
+	interrupt         atomic.Bool    // Atomic flag to signal execution interruption
+	reason            error          // Textual reason for the interruption
+	chainConfig       *params.ChainConfig
 	activePrecompiles []common.Address // Updated on tx start based on given rules
 }
 
 // newFourByteTracer returns a native go tracer which collects
 // 4 byte-identifiers of a tx, and implements vm.EVMLogger.
-func newFourByteTracer(ctx *tracers.Context, _ json.RawMessage) (*tracers.Tracer, error) {
+func newFourByteTracer(ctx *tracers.Context, _ json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	t := &fourByteTracer{
-		ids: make(map[string]int),
+		ids:         make(map[string]int),
+		chainConfig: chainConfig,
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
@@ -88,7 +91,7 @@ func (t *fourByteTracer) store(id []byte, size int) {
 
 func (t *fourByteTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	// Update list of precompiles based on current block
-	rules := env.ChainConfig.Rules(env.BlockNumber)
+	rules := t.chainConfig.Rules(env.BlockNumber)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 }
 

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
@@ -120,7 +121,7 @@ type callTracerConfig struct {
 
 // newCallTracer returns a native go tracer which tracks
 // call frames of a tx, and implements vm.EVMLogger.
-func newCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	t, err := newCallTracerObject(ctx, cfg)
 	if err != nil {
 		return nil, err

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -141,10 +141,8 @@ func newCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *param
 
 func newCallTracerObject(ctx *tracers.Context, cfg json.RawMessage) (*callTracer, error) {
 	var config callTracerConfig
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, err
 	}
 	// First callframe contains tx context info
 	// and is populated on start and end.

--- a/eth/tracers/native/call2.go
+++ b/eth/tracers/native/call2.go
@@ -143,10 +143,8 @@ func newCallTracer2(ctx *tracers.Context, cfg json.RawMessage, chainConfig *para
 
 func newCallTracer2Object(ctx *tracers.Context, cfg json.RawMessage) (*callTracer2, error) {
 	var config callTracer2Config
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, err
 	}
 	// First callframe contains tx context info
 	// and is populated on start and end.

--- a/eth/tracers/native/call2.go
+++ b/eth/tracers/native/call2.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type callFrame2 -field-override callFrame2Marshaling -out gen_callframe2_json.go
@@ -122,7 +123,7 @@ type callTracer2Config struct {
 
 // newCallTracer returns a native go tracer which tracks
 // call frames of a tx, and implements vm.EVMLogger.
-func newCallTracer2(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newCallTracer2(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	t, err := newCallTracer2Object(ctx, cfg)
 	if err != nil {
 		return nil, err

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -127,15 +127,13 @@ type flatCallTracerConfig struct {
 // newFlatCallTracer returns a new flatCallTracer.
 func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config flatCallTracerConfig
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, err
 	}
 
 	// Create inner call tracer with default configuration, don't forward
 	// the OnlyTopCall or WithLog to inner for now
-	t, err := newCallTracerObject(ctx, nil)
+	t, err := newCallTracerObject(ctx, json.RawMessage("{}"))
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type flatCallAction -field-override flatCallActionMarshaling -out gen_flatcallaction_json.go
@@ -114,6 +115,7 @@ type flatCallTracer struct {
 	config            flatCallTracerConfig
 	ctx               *tracers.Context // Holds tracer context data
 	reason            error            // Textual reason for the interruption
+	chainConfig       *params.ChainConfig
 	activePrecompiles []common.Address // Updated on tx start based on given rules
 }
 
@@ -123,7 +125,7 @@ type flatCallTracerConfig struct {
 }
 
 // newFlatCallTracer returns a new flatCallTracer.
-func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config flatCallTracerConfig
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {
@@ -138,7 +140,7 @@ func newFlatCallTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Trac
 		return nil, err
 	}
 
-	ft := &flatCallTracer{tracer: t, ctx: ctx, config: config}
+	ft := &flatCallTracer{tracer: t, ctx: ctx, config: config, chainConfig: chainConfig}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
 			OnTxStart: ft.OnTxStart,
@@ -195,7 +197,7 @@ func (t *flatCallTracer) OnExit(depth int, output []byte, gasUsed uint64, err er
 func (t *flatCallTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	t.tracer.OnTxStart(env, tx, from)
 	// Update list of precompiles based on current block
-	rules := env.ChainConfig.Rules(env.BlockNumber)
+	rules := t.chainConfig.Rules(env.BlockNumber)
 	t.activePrecompiles = vm.ActivePrecompiles(rules)
 }
 

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -41,10 +41,8 @@ type muxTracer struct {
 // newMuxTracer returns a new mux tracer.
 func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config map[string]json.RawMessage
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, err
 	}
 	objects := make([]*tracers.Tracer, 0, len(config))
 	names := make([]string, 0, len(config))

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func init() {
@@ -38,7 +39,7 @@ type muxTracer struct {
 }
 
 // newMuxTracer returns a new mux tracer.
-func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config map[string]json.RawMessage
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {
@@ -48,7 +49,7 @@ func newMuxTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, e
 	objects := make([]*tracers.Tracer, 0, len(config))
 	names := make([]string, 0, len(config))
 	for k, v := range config {
-		t, err := tracers.DefaultDirectory.New(k, ctx, v)
+		t, err := tracers.DefaultDirectory.New(k, ctx, v, chainConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func init() {
@@ -35,7 +36,7 @@ func init() {
 type noopTracer struct{}
 
 // newNoopTracer returns a new noop tracer.
-func newNoopTracer(ctx *tracers.Context, _ json.RawMessage) (*tracers.Tracer, error) {
+func newNoopTracer(ctx *tracers.Context, _ json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	t := &noopTracer{}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -77,10 +77,8 @@ type prestateTracerConfig struct {
 
 func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config prestateTracerConfig
-	if cfg != nil {
-		if err := json.Unmarshal(cfg, &config); err != nil {
-			return nil, err
-		}
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		return nil, err
 	}
 	t := &prestateTracer{
 		pre:     stateMap{},

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/eth/tracers/internal"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
@@ -74,7 +75,7 @@ type prestateTracerConfig struct {
 	DiffMode bool `json:"diffMode"` // If true, this tracer will return state modifications
 }
 
-func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage) (*tracers.Tracer, error) {
+func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *params.ChainConfig) (*tracers.Tracer, error) {
 	var config prestateTracerConfig
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {


### PR DESCRIPTION
Reference PR: https://github.com/ethereum/go-ethereum/pull/30540

In this PR:
- Add missing `noop` live tracer.
- Move `ChainConfig` to tracers as a field instead of getting from `OnTxStart`.
- Rename `supply` struct to `supplyTracer`.
- Set default tracer config to empty obj.