### PR TITLE
genesis: config Prague hardfork block for testnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -40,6 +40,7 @@
     "shanghaiBlock": 35574800,
     "cancunBlock": 35574800,
     "venokiBlock": 35574800,
+    "pragueBlock": 38252600,
     "whiteListDeployerContractV2Address": "0x50a7e07Aa75eB9C04281713224f50403cA79851F",
     "roninTreasuryAddress": "0x5cfca565c09cc32bb7ba7222a648f1b014d6c30b",
     "roninTrustedOrgUpgrade": {


### PR DESCRIPTION
This PR sets the Prague hardfork block for Ronin on testnet. 
The testnet is expected to reach this block at `Thursday, May 29, 2025, 07:08:37 UTC`.