### PR TITLE
genesis,params: config Kotaro hardfork testnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -40,6 +40,7 @@
     "shanghaiBlock": 35574800,
     "cancunBlock": 35574800,
     "venokiBlock": 35574800,
+    "kotaroBlock": 38396600,
     "whiteListDeployerContractV2Address": "0x50a7e07Aa75eB9C04281713224f50403cA79851F",
     "roninTreasuryAddress": "0x5cfca565c09cc32bb7ba7222a648f1b014d6c30b",
     "roninTrustedOrgUpgrade": {

--- a/params/config.go
+++ b/params/config.go
@@ -355,6 +355,7 @@ var (
 		ShanghaiBlock:        big.NewInt(35554400),
 		CancunBlock:          big.NewInt(35554400),
 		VenokiBlock:          big.NewInt(35554400),
+		KotaroBlock:          big.NewInt(38396600),
 		RoninTreasuryAddress: &RoninTestnetTreasuryAddress,
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1  // Major version component of the current release
-	VersionMinor = 0  // Minor version component of the current release
-	VersionPatch = 2  // Patch version component of the current release
-	VersionMeta  = "" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 0          // Minor version component of the current release
+	VersionPatch = 3          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
- Add testnet block to activate Kotaro hardfork
- Update ronin version to v1.0.3-unstable
