### PR TITLE
core,eth,rpc: add justified block query, avoid crash if finalized block is nil

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -62,6 +62,18 @@ func (bc *BlockChain) FinalizedBlock() *types.Block {
 	return nil
 }
 
+func (bc *BlockChain) JustifiedBlock() *types.Block {
+	if consensusEngine, ok := bc.engine.(consensus.FastFinalityPoSA); ok {
+		currentBlock := bc.CurrentBlock()
+		justifiedNumber, justifiedHash := consensusEngine.GetJustifiedBlock(bc, currentBlock.NumberU64(), currentBlock.Hash())
+		if justifiedNumber == 0 {
+			return nil
+		}
+		return rawdb.ReadBlock(bc.db, justifiedHash, justifiedNumber)
+	}
+	return nil
+}
+
 func (bc *BlockChain) CurrentFinalBlock() *types.Header {
 	if finalizedBlock := bc.FinalizedBlock(); finalizedBlock != nil {
 		return finalizedBlock.Header()

--- a/eth/api.go
+++ b/eth/api.go
@@ -310,6 +310,8 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 		block = api.eth.blockchain.CurrentBlock()
 	} else if blockNr == rpc.FinalizedBlockNumber {
 		block = api.eth.blockchain.FinalizedBlock()
+	} else if blockNr == rpc.JustifiedBlockNumber {
+		block = api.eth.blockchain.JustifiedBlock()
 	} else {
 		block = api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
 	}
@@ -400,6 +402,8 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 				block = api.eth.blockchain.CurrentBlock()
 			} else if number == rpc.FinalizedBlockNumber {
 				block = api.eth.blockchain.FinalizedBlock()
+			} else if number == rpc.JustifiedBlockNumber {
+				block = api.eth.blockchain.JustifiedBlock()
 			} else {
 				block = api.eth.blockchain.GetBlockByNumber(uint64(number))
 			}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -221,10 +221,14 @@ func (b *EthAPIBackend) BlobSidecarsByNumber(ctx context.Context, number rpc.Blo
 		hash = b.eth.blockchain.CurrentBlock().Hash()
 	}
 	if number == rpc.FinalizedBlockNumber {
-		hash = b.eth.blockchain.FinalizedBlock().Hash()
+		if finalizedBlock := b.eth.blockchain.FinalizedBlock(); finalizedBlock != nil {
+			hash = finalizedBlock.Hash()
+		}
 	}
 	if number == rpc.JustifiedBlockNumber {
-		hash = b.eth.blockchain.JustifiedBlock().Hash()
+		if justifiedBlock := b.eth.blockchain.JustifiedBlock(); justifiedBlock != nil {
+			hash = justifiedBlock.Hash()
+		}
 	}
 	if hash != (common.Hash{}) {
 		b.eth.blockchain.GetBlobSidecarsByHash(hash)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -84,6 +84,12 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 			return nil, errors.New("header not found")
 		}
 	}
+	if number == rpc.JustifiedBlockNumber {
+		justifiedBlock := b.eth.blockchain.JustifiedBlock()
+		if justifiedBlock != nil {
+			return justifiedBlock.Header(), nil
+		}
+	}
 
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
@@ -121,6 +127,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	}
 	if number == rpc.FinalizedBlockNumber {
 		return b.eth.blockchain.FinalizedBlock(), nil
+	}
+	if number == rpc.JustifiedBlockNumber {
+		return b.eth.blockchain.JustifiedBlock(), nil
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }
@@ -213,6 +222,9 @@ func (b *EthAPIBackend) BlobSidecarsByNumber(ctx context.Context, number rpc.Blo
 	}
 	if number == rpc.FinalizedBlockNumber {
 		hash = b.eth.blockchain.FinalizedBlock().Hash()
+	}
+	if number == rpc.JustifiedBlockNumber {
+		hash = b.eth.blockchain.JustifiedBlock().Hash()
 	}
 	if hash != (common.Hash{}) {
 		b.eth.blockchain.GetBlobSidecarsByHash(hash)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -88,6 +88,8 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		justifiedBlock := b.eth.blockchain.JustifiedBlock()
 		if justifiedBlock != nil {
 			return justifiedBlock.Header(), nil
+		} else {
+			return nil, errors.New("header not found")
 		}
 	}
 
@@ -126,10 +128,20 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
-		return b.eth.blockchain.FinalizedBlock(), nil
+		finalizedBlock := b.eth.blockchain.FinalizedBlock()
+		if finalizedBlock != nil {
+			return finalizedBlock, nil
+		} else {
+			return nil, errors.New("block not found")
+		}
 	}
 	if number == rpc.JustifiedBlockNumber {
-		return b.eth.blockchain.JustifiedBlock(), nil
+		justifiedBlock := b.eth.blockchain.JustifiedBlock()
+		if justifiedBlock != nil {
+			return justifiedBlock, nil
+		} else {
+			return nil, errors.New("block not found")
+		}
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }
@@ -223,11 +235,15 @@ func (b *EthAPIBackend) BlobSidecarsByNumber(ctx context.Context, number rpc.Blo
 	if number == rpc.FinalizedBlockNumber {
 		if finalizedBlock := b.eth.blockchain.FinalizedBlock(); finalizedBlock != nil {
 			hash = finalizedBlock.Hash()
+		} else {
+			return nil, errors.New("finalized block not found")
 		}
 	}
 	if number == rpc.JustifiedBlockNumber {
 		if justifiedBlock := b.eth.blockchain.JustifiedBlock(); justifiedBlock != nil {
 			hash = justifiedBlock.Hash()
+		} else {
+			return nil, errors.New("justified block not found")
 		}
 	}
 	if hash != (common.Hash{}) {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -550,6 +550,9 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(big.NewInt(int64(rpc.FinalizedBlockNumber))) == 0 {
 		return "finalized"
 	}
+	if number.Cmp(big.NewInt(int64(rpc.JustifiedBlockNumber))) == 0 {
+		return "justified"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -66,7 +66,7 @@ const (
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
-// - "latest", "earliest" or "pending" as string arguments
+// - "latest", "earliest", "pending", "justified" or "finalized" as string arguments
 // - the block number
 // Returned errors:
 // - an invalid block number error when the given argument isn't a known strings
@@ -107,7 +107,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalText implements encoding.TextMarshaler. It marshals:
-// - "latest", "earliest" or "pending" as strings
+// - "latest", "earliest", "pending", "justified" or "finalized" as strings
 // - other numbers as hex
 func (bn BlockNumber) MarshalText() ([]byte, error) {
 	switch bn {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -58,6 +58,7 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	JustifiedBlockNumber = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	PendingBlockNumber   = BlockNumber(-2)
 	LatestBlockNumber    = BlockNumber(-1)
@@ -86,6 +87,9 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
+	case "justified":
+		*bn = JustifiedBlockNumber
+		return nil
 	case "finalized":
 		*bn = FinalizedBlockNumber
 		return nil
@@ -113,6 +117,8 @@ func (bn BlockNumber) MarshalText() ([]byte, error) {
 		return []byte("latest"), nil
 	case PendingBlockNumber:
 		return []byte("pending"), nil
+	case JustifiedBlockNumber:
+		return []byte("justified"), nil
 	case FinalizedBlockNumber:
 		return []byte("finalized"), nil
 	default:
@@ -159,6 +165,10 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "pending":
 		bn := PendingBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "justified":
+		bn := JustifiedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	case "finalized":

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -48,6 +48,8 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		14: {`someString`, true, BlockNumber(0)},
 		15: {`""`, true, BlockNumber(0)},
 		16: {``, true, BlockNumber(0)},
+		17: {`"justified"`, false, JustifiedBlockNumber},
+		18: {`"finalized"`, false, FinalizedBlockNumber},
 	}
 
 	for i, test := range tests {
@@ -99,6 +101,8 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		23: {`{"blockNumber":"latest"}`, false, BlockNumberOrHashWithNumber(LatestBlockNumber)},
 		24: {`{"blockNumber":"earliest"}`, false, BlockNumberOrHashWithNumber(EarliestBlockNumber)},
 		25: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+		26: {`"justified"`, false, BlockNumberOrHashWithNumber(JustifiedBlockNumber)},
+		27: {`"finalized"`, false, BlockNumberOrHashWithNumber(FinalizedBlockNumber)},
 	}
 
 	for i, test := range tests {
@@ -133,6 +137,8 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		{"pending", int64(PendingBlockNumber)},
 		{"latest", int64(LatestBlockNumber)},
 		{"earliest", int64(EarliestBlockNumber)},
+		{"justified", int64(JustifiedBlockNumber)},
+		{"finalized", int64(FinalizedBlockNumber)},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
This PR introduces:
- The new "justified" block number support for the JSON-RPC API to allow clients to query the justified block
- Handle case nil finalized block causes panic in retrieving blob sidecar